### PR TITLE
Added pv to allowed CORS origins to fix CH5 issue

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -20,8 +20,15 @@ const corsOptions = {
     if (!origin) return callback(null, true);
     
     const allowedOrigins = process.env.CORS_ORIGIN ? 
-      process.env.CORS_ORIGIN.split(',').map(o => o.trim()) : 
-      ['https://wayneaws.dev', 'https://www.wayneaws.dev', 'http://localhost:5173', 'http://localhost:3000'];
+    process.env.CORS_ORIGIN.split(',').map(o => o.trim()) : 
+    [
+      'https://wayneaws.dev', 
+      'https://www.wayneaws.dev', 
+      'https://prizeversity.com',      
+      'https://www.prizeversity.com',  
+      'http://localhost:5173', 
+      'http://localhost:3000'
+    ];
     
     if (allowedOrigins.includes(origin)) {
       callback(null, true);


### PR DESCRIPTION
This patch is meant to fix the Network Fetch errors students get when attempting to complete Challenge 5 on Prizeversity.