### PR TITLE
fix: isolate on the `.language-chip` to create a new stacking context

### DIFF
--- a/frontend/src/pages/styles/QuickSetup.css
+++ b/frontend/src/pages/styles/QuickSetup.css
@@ -382,6 +382,7 @@
   text-align: center;
   position: relative;
   overflow: hidden;
+  isolation: isolate;
 }
 
 .language-chip::before {


### PR DESCRIPTION
Fixes #78