### PR TITLE
feat: add verified Prizeversity-backed challenge rewards

### DIFF
--- a/backend/scripts/createSuperuser.ts
+++ b/backend/scripts/createSuperuser.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env bun
+
 import mongoose from 'mongoose';
 
 import env from '../src/config/env';
@@ -64,6 +66,7 @@ if (!email) {
   log.info('email address is required.');
   log.info('');
   log.info('usage.');
+  log.info('   ./scripts/createSuperuser.ts <email>');
   log.info('   bun run create-superuser -- <email>');
   log.info('');
   log.info('example.');

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,6 +8,7 @@ import authRoutes from './routes/auth';
 import discordInviteRoutes from './routes/discordInvite';
 import eventRoutes from './routes/events';
 import newsletterRoutes from './routes/newsletter';
+import rewardIntegrationRoutes from './routes/rewardIntegration';
 import uploadRoutes from './routes/upload';
 import verifyRoutes from './routes/verify';
 import env from './config/env';
@@ -150,6 +151,7 @@ app.use('/upload', uploadRoutes);
 app.use('/', discordInviteRoutes);
 app.use('/admin', adminRoutes);
 app.use('/events', eventRoutes);
+app.use('/integrations/prizeversity', rewardIntegrationRoutes);
 app.use('/verify', verifyRoutes);
 
 app.get('/health', (_req: Request, res: Response): void => {

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -85,6 +85,10 @@ const env = {
   DISCORD_GUILD_ID: optionalString('DISCORD_GUILD_ID'),
   DISCORD_CHANNEL_ID: optionalString('DISCORD_CHANNEL_ID'),
   AWS_CRED_ENCRYPTION_KEY: optionalString('AWS_CRED_ENCRYPTION_KEY'),
+
+  PRIZEVERSITY_API_URL: stringValue('PRIZEVERSITY_API_URL', 'https://www.prizeversity.com'),
+  PRIZEVERSITY_API_KEY: optionalString('PRIZEVERSITY_API_KEY'),
+  PRIZEVERSITY_CLASSROOM_ID: optionalString('PRIZEVERSITY_CLASSROOM_ID'),
 } as const;
 
 export default env;

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -32,6 +32,13 @@ interface AuthResponseBody {
   };
 }
 
+interface AwsCredentialUser {
+  awsAccessKeyId?: string;
+  awsSecretAccessKey?: string;
+  prizeversityUserId?: string;
+  prizeversityClassroomId?: string;
+}
+
 const filter = new Filter();
 
 const getJwtSecret = (): string => {
@@ -101,6 +108,47 @@ const generateTokens = (user: TokenUser, deviceId: string, rememberMe = false) =
   const refreshToken = user.generateRefreshToken(deviceId, rememberMe);
 
   return { accessToken, refreshToken };
+};
+
+const hasPrizeversityChallengeLink = (user: AwsCredentialUser): boolean => {
+  return Boolean(user.prizeversityUserId && user.prizeversityClassroomId);
+};
+
+const attachAwsCredentialsIfLinked = (
+  userObj: Record<string, unknown>,
+  user: AwsCredentialUser
+): void => {
+  delete userObj.awsAccessKeyId;
+  delete userObj.awsSecretAccessKey;
+
+  if (hasPrizeversityChallengeLink(user) && user.awsAccessKeyId && user.awsSecretAccessKey) {
+    userObj.awsAccessKeyId = user.awsAccessKeyId;
+    userObj.awsSecretAccessKey = user.awsSecretAccessKey;
+  }
+};
+
+const getRefreshTokenRememberMe = (
+  user: {
+    refreshTokens?: Array<{
+      token: string;
+      deviceId: string;
+      expiresAt: Date;
+      rememberMe?: boolean;
+    }>;
+  },
+  refreshToken: string,
+  deviceId: string
+): boolean => {
+  const tokenEntry = user.refreshTokens?.find(
+    (entry) => entry.token === refreshToken && entry.deviceId === deviceId
+  );
+  if (!tokenEntry) return false;
+  if (typeof tokenEntry.rememberMe === 'boolean') return tokenEntry.rememberMe;
+
+  const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+  const expiresAt =
+    tokenEntry.expiresAt instanceof Date ? tokenEntry.expiresAt : new Date(tokenEntry.expiresAt);
+  return expiresAt.getTime() - Date.now() > sevenDaysMs;
 };
 
 const generateUsername = async (email: string): Promise<string> => {
@@ -233,10 +281,7 @@ export const signup = async (req: Request, res: Response): Promise<void> => {
     await user.save();
 
     const userObj = user.toSafeObject();
-    if (user.awsAccessKeyId && user.awsSecretAccessKey) {
-      userObj.awsAccessKeyId = user.awsAccessKeyId;
-      userObj.awsSecretAccessKey = user.awsSecretAccessKey;
-    }
+    attachAwsCredentialsIfLinked(userObj, user);
 
     const response: AuthResponseBody = {
       accessToken,
@@ -246,7 +291,7 @@ export const signup = async (req: Request, res: Response): Promise<void> => {
       user: userObj,
     };
 
-    if (awsCredentials) {
+    if (awsCredentials && hasPrizeversityChallengeLink(user)) {
       response.awsCredentials = awsCredentials;
     }
 
@@ -312,16 +357,11 @@ export const login = async (req: Request, res: Response): Promise<void> => {
 
     const { accessToken, refreshToken } = generateTokens(user, currentDeviceId, !!rememberMe);
 
-    setImmediate(() => {
-      user.lastLogin = new Date();
-      user.save().catch((err: unknown) => log.error('failed to update user data.', err));
-    });
+    user.lastLogin = new Date();
+    await user.save();
 
     const userObj = user.toSafeObject();
-    if (user.awsAccessKeyId && user.awsSecretAccessKey) {
-      userObj.awsAccessKeyId = user.awsAccessKeyId;
-      userObj.awsSecretAccessKey = user.awsSecretAccessKey;
-    }
+    attachAwsCredentialsIfLinked(userObj, user);
 
     res.json({
       accessToken,
@@ -362,10 +402,7 @@ export const getCurrentUser = async (req: Request, res: Response): Promise<void>
     }
 
     const userObj = user.toSafeObject();
-    if (user.awsAccessKeyId && user.awsSecretAccessKey) {
-      userObj.awsAccessKeyId = user.awsAccessKeyId;
-      userObj.awsSecretAccessKey = user.awsSecretAccessKey;
-    }
+    attachAwsCredentialsIfLinked(userObj, user);
 
     res.json(userObj);
   } catch (error: unknown) {
@@ -853,9 +890,15 @@ export const refreshToken = async (req: Request, res: Response): Promise<void> =
       return;
     }
 
+    const rememberMe = getRefreshTokenRememberMe(user, refreshToken, deviceId);
+
     user.cleanExpiredRefreshTokens();
 
-    const { accessToken, refreshToken: newRefreshToken } = generateTokens(user, deviceId);
+    const { accessToken, refreshToken: newRefreshToken } = generateTokens(
+      user,
+      deviceId,
+      rememberMe
+    );
 
     user.revokeRefreshToken(refreshToken);
 
@@ -864,6 +907,8 @@ export const refreshToken = async (req: Request, res: Response): Promise<void> =
     res.json({
       accessToken,
       refreshToken: newRefreshToken,
+      deviceId,
+      rememberMe,
       user: user.toSafeObject(),
     });
   } catch (error: unknown) {
@@ -901,7 +946,7 @@ export const logout = async (req: Request, res: Response): Promise<void> => {
     } else if (refreshToken) {
       user.revokeRefreshToken(refreshToken);
     } else if (deviceId) {
-      user.refreshTokens = user.refreshTokens.filter(
+      user.refreshTokens = (Array.isArray(user.refreshTokens) ? user.refreshTokens : []).filter(
         (token: { deviceId: string }) => token.deviceId !== deviceId
       );
     }
@@ -938,11 +983,18 @@ export const getAwsCredentials = async (req: Request, res: Response): Promise<vo
     }
 
     const user = await User.findById(userId).select(
-      '+password +awsAccessKeyId +awsSecretAccessKey'
+      '+password +awsAccessKeyId +awsSecretAccessKey prizeversityUserId prizeversityClassroomId'
     );
     if (!user) {
       res.status(404).json({
         error: 'User not found',
+      });
+      return;
+    }
+
+    if (!hasPrizeversityChallengeLink(user)) {
+      res.status(403).json({
+        error: 'Link your Prizeversity account before accessing AWS challenge credentials',
       });
       return;
     }

--- a/backend/src/controllers/rewardIntegrationAdminController.ts
+++ b/backend/src/controllers/rewardIntegrationAdminController.ts
@@ -1,0 +1,110 @@
+import { Request, Response } from 'express';
+
+import {
+  createRewardIntegrationInstance,
+  deactivateRewardIntegrationInstance,
+  listRewardIntegrationInstances,
+  testRewardIntegrationInstance,
+  updateRewardIntegrationInstance,
+} from '../services/rewardIntegrationService';
+
+const getAdminUserId = (req: Request): string | null => req.user?.id || null;
+
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  return error instanceof Error ? error.message : fallback;
+};
+
+export const listInstances = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const instances = await listRewardIntegrationInstances();
+    res.json({ instances });
+  } catch (error: unknown) {
+    res.status(500).json({
+      error: getErrorMessage(error, 'Unable to list reward integration instances'),
+    });
+  }
+};
+
+export const createInstance = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const adminUserId = getAdminUserId(req);
+    if (!adminUserId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    const instance = await createRewardIntegrationInstance(req.body || {}, adminUserId);
+    res.status(201).json({
+      message: 'Reward integration instance created',
+      instance,
+    });
+  } catch (error: unknown) {
+    res.status(400).json({
+      error: getErrorMessage(error, 'Unable to create reward integration instance'),
+    });
+  }
+};
+
+export const updateInstance = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const adminUserId = getAdminUserId(req);
+    if (!adminUserId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    const instance = await updateRewardIntegrationInstance(
+      req.params.instanceId,
+      req.body || {},
+      adminUserId
+    );
+    res.json({
+      message: 'Reward integration instance updated',
+      instance,
+    });
+  } catch (error: unknown) {
+    res.status(400).json({
+      error: getErrorMessage(error, 'Unable to update reward integration instance'),
+    });
+  }
+};
+
+export const testInstance = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const adminUserId = getAdminUserId(req);
+    if (!adminUserId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    const result = await testRewardIntegrationInstance(req.params.instanceId, adminUserId);
+    res.json({
+      message: 'Reward integration instance verified',
+      ...result,
+    });
+  } catch (error: unknown) {
+    res.status(400).json({
+      error: getErrorMessage(error, 'Unable to verify reward integration instance'),
+    });
+  }
+};
+
+export const deactivateInstance = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const adminUserId = getAdminUserId(req);
+    if (!adminUserId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    const instance = await deactivateRewardIntegrationInstance(req.params.instanceId, adminUserId);
+    res.json({
+      message: 'Reward integration instance deactivated',
+      instance,
+    });
+  } catch (error: unknown) {
+    res.status(400).json({
+      error: getErrorMessage(error, 'Unable to deactivate reward integration instance'),
+    });
+  }
+};

--- a/backend/src/middleware/adminAuth.ts
+++ b/backend/src/middleware/adminAuth.ts
@@ -8,6 +8,7 @@ import logger from '../config/logger';
 const log = logger.child({ module: 'adminAuth' });
 
 type Role = Express.UserRole;
+type UserStatus = Express.UserStatus;
 
 interface AdminTokenPayload extends jwt.JwtPayload {
   id: string;
@@ -53,7 +54,7 @@ export const requireRole = (minRole: Role = 'member'): RequestHandler => {
         return;
       }
 
-      const user = await User.findById(decoded.id).select('+role +status email');
+      const user = await User.findById(decoded.id).select('role status email');
 
       if (!user) {
         res.status(401).json({
@@ -62,9 +63,11 @@ export const requireRole = (minRole: Role = 'member'): RequestHandler => {
         return;
       }
 
-      if (user.status !== 'active') {
+      const userStatus = (user.status || 'active') as UserStatus;
+
+      if (userStatus !== 'active') {
         res.status(403).json({
-          error: `Account is ${user.status}. Access denied.`,
+          error: `Account is ${userStatus}. Access denied.`,
         });
         return;
       }
@@ -84,7 +87,7 @@ export const requireRole = (minRole: Role = 'member'): RequestHandler => {
         id: String(user._id),
         email: user.email,
         role: userRole,
-        status: user.status,
+        status: userStatus,
       };
 
       next();

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -6,6 +6,7 @@ import User from '../models/User';
 import logger from '../config/logger';
 
 const log = logger.child({ module: 'auth' });
+type UserStatus = Express.UserStatus;
 
 interface AccessTokenPayload extends jwt.JwtPayload {
   id: string;
@@ -54,7 +55,9 @@ const checkJwt = async (req: Request, res: Response, next: NextFunction): Promis
       return;
     }
 
-    if (user.status !== 'active') {
+    const userStatus = (user.status || 'active') as UserStatus;
+
+    if (userStatus !== 'active') {
       res.status(401).json({
         error: 'Account is not active',
       });

--- a/backend/src/models/RewardIntegrationEmission.ts
+++ b/backend/src/models/RewardIntegrationEmission.ts
@@ -1,0 +1,90 @@
+import mongoose, { HydratedDocument, Model, Schema, Types } from 'mongoose';
+
+export type RewardIntegrationEmissionStatus = 'pending' | 'sent' | 'failed';
+
+export interface IRewardIntegrationEmission {
+  awsUserId: Types.ObjectId;
+  prizeversityUserId: string;
+  classroomId: string;
+  challengeKey: string;
+  activityName: string;
+  status: RewardIntegrationEmissionStatus;
+  requestPayload: Record<string, unknown>;
+  responsePayload?: Record<string, unknown>;
+  errorMessage?: string;
+  sentAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type IRewardIntegrationEmissionDocument = HydratedDocument<IRewardIntegrationEmission>;
+type RewardIntegrationEmissionModel = Model<IRewardIntegrationEmission>;
+
+const rewardIntegrationEmissionSchema = new Schema<
+  IRewardIntegrationEmission,
+  RewardIntegrationEmissionModel
+>(
+  {
+    awsUserId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    prizeversityUserId: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    classroomId: {
+      type: String,
+      required: true,
+      trim: true,
+      index: true,
+    },
+    challengeKey: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    activityName: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    status: {
+      type: String,
+      enum: ['pending', 'sent', 'failed'],
+      default: 'pending',
+      index: true,
+    },
+    requestPayload: {
+      type: Schema.Types.Mixed,
+      required: true,
+    },
+    responsePayload: {
+      type: Schema.Types.Mixed,
+    },
+    errorMessage: {
+      type: String,
+    },
+    sentAt: {
+      type: Date,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+rewardIntegrationEmissionSchema.index(
+  { awsUserId: 1, classroomId: 1, challengeKey: 1 },
+  { unique: true }
+);
+
+const RewardIntegrationEmission = mongoose.model<
+  IRewardIntegrationEmission,
+  RewardIntegrationEmissionModel
+>('RewardIntegrationEmission', rewardIntegrationEmissionSchema);
+
+export default RewardIntegrationEmission;

--- a/backend/src/models/RewardIntegrationInstance.ts
+++ b/backend/src/models/RewardIntegrationInstance.ts
@@ -1,0 +1,129 @@
+import mongoose, { HydratedDocument, Model, Schema, Types } from 'mongoose';
+
+export type RewardIntegrationProvider = 'prizeversity';
+export type RewardIntegrationVerificationStatus = 'untested' | 'verified' | 'failed';
+
+export interface IRewardIntegrationInstance {
+  name: string;
+  description?: string;
+  provider: RewardIntegrationProvider;
+  apiBaseUrl: string;
+  apiKey: string;
+  apiKeyPreview: string;
+  classroomId: string;
+  classroomName?: string;
+  scopes: string[];
+  active: boolean;
+  lastVerifiedAt?: Date | null;
+  lastVerificationStatus: RewardIntegrationVerificationStatus;
+  lastVerificationError?: string;
+  lastUserCount?: number;
+  createdBy: Types.ObjectId;
+  updatedBy?: Types.ObjectId;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type IRewardIntegrationInstanceDocument = HydratedDocument<IRewardIntegrationInstance>;
+type RewardIntegrationInstanceModel = Model<IRewardIntegrationInstance>;
+
+const rewardIntegrationInstanceSchema = new Schema<
+  IRewardIntegrationInstance,
+  RewardIntegrationInstanceModel
+>(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 120,
+    },
+    description: {
+      type: String,
+      trim: true,
+      maxlength: 500,
+      default: '',
+    },
+    provider: {
+      type: String,
+      enum: ['prizeversity'],
+      default: 'prizeversity',
+      required: true,
+      index: true,
+    },
+    apiBaseUrl: {
+      type: String,
+      required: true,
+      trim: true,
+      default: 'https://www.prizeversity.com',
+    },
+    apiKey: {
+      type: String,
+      required: true,
+      select: false,
+    },
+    apiKeyPreview: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    classroomId: {
+      type: String,
+      required: true,
+      trim: true,
+      index: true,
+    },
+    classroomName: {
+      type: String,
+      trim: true,
+      default: '',
+    },
+    scopes: {
+      type: [String],
+      default: ['users:read', 'users:match', 'reward:grant'],
+    },
+    active: {
+      type: Boolean,
+      default: true,
+      index: true,
+    },
+    lastVerifiedAt: {
+      type: Date,
+      default: null,
+    },
+    lastVerificationStatus: {
+      type: String,
+      enum: ['untested', 'verified', 'failed'],
+      default: 'untested',
+    },
+    lastVerificationError: {
+      type: String,
+    },
+    lastUserCount: {
+      type: Number,
+      min: 0,
+    },
+    createdBy: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    updatedBy: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+rewardIntegrationInstanceSchema.index({ provider: 1, classroomId: 1, active: 1 });
+
+const RewardIntegrationInstance = mongoose.model<
+  IRewardIntegrationInstance,
+  RewardIntegrationInstanceModel
+>('RewardIntegrationInstance', rewardIntegrationInstanceSchema);
+
+export default RewardIntegrationInstance;

--- a/backend/src/models/RewardIntegrationLinkVerification.ts
+++ b/backend/src/models/RewardIntegrationLinkVerification.ts
@@ -1,0 +1,95 @@
+import mongoose, { HydratedDocument, Model, Schema, Types } from 'mongoose';
+
+export interface IRewardIntegrationLinkVerification {
+  awsUserId: Types.ObjectId;
+  rewardIntegrationInstanceId?: Types.ObjectId | null;
+  prizeversityUserId: string;
+  classroomId: string;
+  email: string;
+  matchedName?: string;
+  shortId?: string;
+  codeHash: string;
+  codeSalt: string;
+  attempts: number;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type IRewardIntegrationLinkVerificationDocument =
+  HydratedDocument<IRewardIntegrationLinkVerification>;
+type RewardIntegrationLinkVerificationModel = Model<IRewardIntegrationLinkVerification>;
+
+const rewardIntegrationLinkVerificationSchema = new Schema<
+  IRewardIntegrationLinkVerification,
+  RewardIntegrationLinkVerificationModel
+>(
+  {
+    awsUserId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      unique: true,
+      index: true,
+    },
+    rewardIntegrationInstanceId: {
+      type: Schema.Types.ObjectId,
+      ref: 'RewardIntegrationInstance',
+      default: null,
+    },
+    prizeversityUserId: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    classroomId: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    email: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+    },
+    matchedName: {
+      type: String,
+      trim: true,
+    },
+    shortId: {
+      type: String,
+      trim: true,
+    },
+    codeHash: {
+      type: String,
+      required: true,
+    },
+    codeSalt: {
+      type: String,
+      required: true,
+    },
+    attempts: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
+    expiresAt: {
+      type: Date,
+      required: true,
+      index: true,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+rewardIntegrationLinkVerificationSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+const RewardIntegrationLinkVerification = mongoose.model<
+  IRewardIntegrationLinkVerification,
+  RewardIntegrationLinkVerificationModel
+>('RewardIntegrationLinkVerification', rewardIntegrationLinkVerificationSchema);
+
+export default RewardIntegrationLinkVerification;

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -11,6 +11,7 @@ export interface RefreshTokenEntry {
   createdAt: Date;
   expiresAt: Date;
   deviceId: string;
+  rememberMe?: boolean;
 }
 
 export interface IUser {
@@ -84,6 +85,10 @@ const refreshTokenSchema = new Schema<RefreshTokenEntry>(
     deviceId: {
       type: String,
       required: true,
+    },
+    rememberMe: {
+      type: Boolean,
+      default: false,
     },
   },
   { _id: false }
@@ -198,7 +203,10 @@ const userSchema = new Schema<IUser, UserModel, IUserMethods>(
       type: Date,
       select: false,
     },
-    refreshTokens: [refreshTokenSchema],
+    refreshTokens: {
+      type: [refreshTokenSchema],
+      default: [],
+    },
     tokenVersion: {
       type: Number,
       default: 0,
@@ -315,6 +323,12 @@ userSchema.methods.comparePassword = async function (candidatePassword: string):
 userSchema.methods.toSafeObject = function (): Record<string, unknown> {
   const obj = this.toObject() as Record<string, unknown>;
   delete obj.password;
+  delete obj.refreshTokens;
+  delete obj.resetPasswordToken;
+  delete obj.resetPasswordExpires;
+  delete obj.awsAccessKeyId;
+  delete obj.awsSecretAccessKey;
+  delete obj.nextChallengePassword;
   return obj;
 };
 
@@ -330,12 +344,21 @@ userSchema.methods.clearResetToken = function (): void {
   this.resetPasswordExpires = undefined;
 };
 
+const ensureRefreshTokens = (user: {
+  refreshTokens?: RefreshTokenEntry[];
+}): RefreshTokenEntry[] => {
+  if (!Array.isArray(user.refreshTokens)) {
+    user.refreshTokens = [];
+  }
+  return user.refreshTokens;
+};
+
 userSchema.methods.generateRefreshToken = function (deviceId: string, rememberMe = false): string {
   const refreshToken = crypto.randomBytes(64).toString('hex');
   const expirationDays = rememberMe ? 30 : 7;
   const expiresAt = new Date(Date.now() + expirationDays * 24 * 60 * 60 * 1000);
 
-  this.refreshTokens = this.refreshTokens.filter(
+  this.refreshTokens = ensureRefreshTokens(this).filter(
     (token: RefreshTokenEntry) => token.deviceId !== deviceId && token.expiresAt > new Date()
   );
 
@@ -344,6 +367,7 @@ userSchema.methods.generateRefreshToken = function (deviceId: string, rememberMe
     createdAt: new Date(),
     expiresAt,
     deviceId,
+    rememberMe,
   });
 
   if (this.refreshTokens.length > 5) {
@@ -359,7 +383,7 @@ userSchema.methods.generateRefreshToken = function (deviceId: string, rememberMe
 };
 
 userSchema.methods.validateRefreshToken = function (token: string, deviceId: string): boolean {
-  const tokenEntry = this.refreshTokens.find(
+  const tokenEntry = ensureRefreshTokens(this).find(
     (entry: RefreshTokenEntry) =>
       entry.token === token && entry.deviceId === deviceId && entry.expiresAt > new Date()
   );
@@ -367,7 +391,7 @@ userSchema.methods.validateRefreshToken = function (token: string, deviceId: str
 };
 
 userSchema.methods.revokeRefreshToken = function (token: string): void {
-  this.refreshTokens = this.refreshTokens.filter(
+  this.refreshTokens = ensureRefreshTokens(this).filter(
     (entry: RefreshTokenEntry) => entry.token !== token
   );
 };
@@ -378,7 +402,7 @@ userSchema.methods.revokeAllRefreshTokens = function (): void {
 };
 
 userSchema.methods.cleanExpiredRefreshTokens = function (): void {
-  this.refreshTokens = this.refreshTokens.filter(
+  this.refreshTokens = ensureRefreshTokens(this).filter(
     (token: RefreshTokenEntry) => token.expiresAt > new Date()
   );
 };

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -42,6 +42,14 @@ export interface IUser {
   awsAccessKeyId?: string;
   awsSecretAccessKey?: string;
   hasViewedAwsCredentials: boolean;
+  rewardIntegrationInstanceId?: Types.ObjectId | null;
+  prizeversityUserId?: string;
+  prizeversityClassroomId?: string;
+  prizeversityEmail?: string;
+  prizeversityMatchedName?: string;
+  prizeversityShortId?: string;
+  prizeversityLinkedAt?: Date | null;
+  prizeversityLastSyncedAt?: Date | null;
 }
 
 export interface IUserMethods {
@@ -210,6 +218,43 @@ const userSchema = new Schema<IUser, UserModel, IUserMethods>(
     hasViewedAwsCredentials: {
       type: Boolean,
       default: false,
+    },
+    rewardIntegrationInstanceId: {
+      type: Schema.Types.ObjectId,
+      ref: 'RewardIntegrationInstance',
+      default: null,
+      index: true,
+    },
+    prizeversityUserId: {
+      type: String,
+      trim: true,
+      index: true,
+    },
+    prizeversityClassroomId: {
+      type: String,
+      trim: true,
+      index: true,
+    },
+    prizeversityEmail: {
+      type: String,
+      trim: true,
+      lowercase: true,
+    },
+    prizeversityMatchedName: {
+      type: String,
+      trim: true,
+    },
+    prizeversityShortId: {
+      type: String,
+      trim: true,
+    },
+    prizeversityLinkedAt: {
+      type: Date,
+      default: null,
+    },
+    prizeversityLastSyncedAt: {
+      type: Date,
+      default: null,
     },
   },
   {

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 
 import * as adminController from '../controllers/adminController';
+import * as rewardIntegrationAdminController from '../controllers/rewardIntegrationAdminController';
 import { canManageUser, requireAdmin, requireModerator } from '../middleware/adminAuth';
 
 const router = express.Router();
@@ -16,5 +17,22 @@ router.get('/email-queue/stats', requireAdmin, adminController.getEmailQueueStat
 router.get('/email-queue/entries', requireAdmin, adminController.getEmailQueueEntries);
 router.post('/email-queue/:queueId/retry', requireAdmin, adminController.retryQueuedEmail);
 router.post('/email-queue/process', requireAdmin, adminController.processQueue);
+router.get('/reward-integrations', requireAdmin, rewardIntegrationAdminController.listInstances);
+router.post('/reward-integrations', requireAdmin, rewardIntegrationAdminController.createInstance);
+router.put(
+  '/reward-integrations/:instanceId',
+  requireAdmin,
+  rewardIntegrationAdminController.updateInstance
+);
+router.post(
+  '/reward-integrations/:instanceId/test',
+  requireAdmin,
+  rewardIntegrationAdminController.testInstance
+);
+router.delete(
+  '/reward-integrations/:instanceId',
+  requireAdmin,
+  rewardIntegrationAdminController.deactivateInstance
+);
 
 export default router;

--- a/backend/src/routes/rewardIntegration.ts
+++ b/backend/src/routes/rewardIntegration.ts
@@ -1,0 +1,78 @@
+import { Router, Request, Response } from 'express';
+
+import checkJwt from '../middleware/auth';
+import User from '../models/User';
+import {
+  getPrizeversityStatus,
+  linkPrizeversityAccount,
+  unlinkPrizeversityAccount,
+} from '../services/rewardIntegrationService';
+
+const router = Router();
+
+const getAuthenticatedUser = async (req: Request) => {
+  if (!req.user?.id) return null;
+  return User.findById(req.user.id);
+};
+
+router.get('/status', checkJwt, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const user = await getAuthenticatedUser(req);
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    res.json(await getPrizeversityStatus(user));
+  } catch {
+    res.status(500).json({ error: 'Unable to load Prizeversity status' });
+  }
+});
+
+router.post('/link', checkJwt, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const user = await getAuthenticatedUser(req);
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    const identifier =
+      typeof req.body?.identifier === 'string' ? req.body.identifier.trim() : undefined;
+    const instanceId =
+      typeof req.body?.instanceId === 'string' ? req.body.instanceId.trim() : undefined;
+    await linkPrizeversityAccount(user, { identifier, instanceId });
+
+    res.json({
+      message: 'Prizeversity account linked successfully',
+      status: await getPrizeversityStatus(user),
+      user: user.toSafeObject(),
+    });
+  } catch (error: unknown) {
+    res.status(400).json({
+      error: error instanceof Error ? error.message : 'Unable to link Prizeversity account',
+    });
+  }
+});
+
+router.delete('/link', checkJwt, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const user = await getAuthenticatedUser(req);
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    await unlinkPrizeversityAccount(user);
+
+    res.json({
+      message: 'Prizeversity account unlinked successfully',
+      status: await getPrizeversityStatus(user),
+      user: user.toSafeObject(),
+    });
+  } catch {
+    res.status(500).json({ error: 'Unable to unlink Prizeversity account' });
+  }
+});
+
+export default router;

--- a/backend/src/routes/rewardIntegration.ts
+++ b/backend/src/routes/rewardIntegration.ts
@@ -4,8 +4,9 @@ import checkJwt from '../middleware/auth';
 import User from '../models/User';
 import {
   getPrizeversityStatus,
-  linkPrizeversityAccount,
+  startPrizeversityAccountLink,
   unlinkPrizeversityAccount,
+  verifyPrizeversityAccountLink,
 } from '../services/rewardIntegrationService';
 
 const router = Router();
@@ -41,7 +42,31 @@ router.post('/link', checkJwt, async (req: Request, res: Response): Promise<void
       typeof req.body?.identifier === 'string' ? req.body.identifier.trim() : undefined;
     const instanceId =
       typeof req.body?.instanceId === 'string' ? req.body.instanceId.trim() : undefined;
-    await linkPrizeversityAccount(user, { identifier, instanceId });
+    const verification = await startPrizeversityAccountLink(user, { identifier, instanceId });
+
+    res.json({
+      message: `Verification code sent to ${verification.maskedEmail}`,
+      ...verification,
+      status: await getPrizeversityStatus(user),
+      user: user.toSafeObject(),
+    });
+  } catch (error: unknown) {
+    res.status(400).json({
+      error: error instanceof Error ? error.message : 'Unable to link Prizeversity account',
+    });
+  }
+});
+
+router.post('/link/verify', checkJwt, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const user = await getAuthenticatedUser(req);
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    const code = typeof req.body?.code === 'string' ? req.body.code.trim() : '';
+    await verifyPrizeversityAccountLink(user, code);
 
     res.json({
       message: 'Prizeversity account linked successfully',
@@ -50,7 +75,7 @@ router.post('/link', checkJwt, async (req: Request, res: Response): Promise<void
     });
   } catch (error: unknown) {
     res.status(400).json({
-      error: error instanceof Error ? error.message : 'Unable to link Prizeversity account',
+      error: error instanceof Error ? error.message : 'Unable to verify Prizeversity link code',
     });
   }
 });

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -93,6 +93,54 @@ export const sendResetCode = async (
   await transporter.sendMail(mailOptions);
 };
 
+export const sendPrizeversityLinkCode = async (
+  email: string,
+  code: string,
+  fullName: string,
+  classroomName = 'your Prizeversity classroom'
+): Promise<void> => {
+  const mailOptions = {
+    from: `"AWS Student Hub" <${env.SMTP_USER}>`,
+    to: email,
+    subject: 'Prizeversity Link Code - AWS Student Hub',
+    html: `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <style>
+          body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+          .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+          .header { text-align: center; margin-bottom: 30px; }
+          .code-box { background: #f8f9fa; padding: 20px; border-radius: 8px; text-align: center; margin: 20px 0; }
+          .code { font-size: 32px; font-weight: bold; color: #FF9900; letter-spacing: 5px; }
+          .footer { margin-top: 30px; font-size: 14px; color: #666; }
+        </style>
+      </head>
+      <body>
+        <div class="container">
+          <div class="header">
+            <h2>Prizeversity Account Link</h2>
+          </div>
+          <p>Hello ${fullName || 'there'},</p>
+          <p>AWS Student Hub received a request to link this Prizeversity account from ${classroomName} for challenge rewards.</p>
+          <p>Use the code below to finish linking your account:</p>
+          <div class="code-box">
+            <div class="code">${code}</div>
+          </div>
+          <p>This code will expire in 10 minutes.</p>
+          <p>If you did not request this link, you can safely ignore this email.</p>
+          <div class="footer">
+            <p>Best regards,<br>AWS Student Hub Team</p>
+          </div>
+        </div>
+      </body>
+      </html>
+    `,
+  };
+
+  await transporter.sendMail(mailOptions);
+};
+
 export const sendEventNotification = async (
   email: string,
   fullName: string,

--- a/backend/src/services/rewardIntegrationService.ts
+++ b/backend/src/services/rewardIntegrationService.ts
@@ -1,0 +1,797 @@
+import { Types } from 'mongoose';
+
+import env from '../config/env';
+import logger from '../config/logger';
+import RewardIntegrationEmission from '../models/RewardIntegrationEmission';
+import RewardIntegrationInstance, {
+  IRewardIntegrationInstanceDocument,
+} from '../models/RewardIntegrationInstance';
+import type { IUserDocument } from '../models/User';
+
+const log = logger.child({ module: 'reward-integration-service' });
+
+const REQUEST_TIMEOUT_MS = 12000;
+const DEFAULT_PROVIDER = 'prizeversity';
+const DEFAULT_API_BASE_URL = 'https://www.prizeversity.com';
+const DEFAULT_SCOPES = ['users:read', 'users:match', 'reward:grant'];
+
+export interface PublicRewardIntegrationInstance {
+  id: string;
+  source: 'database' | 'environment';
+  provider: 'prizeversity';
+  name: string;
+  description?: string;
+  apiBaseUrl: string;
+  apiKeyPreview?: string;
+  classroomId: string;
+  classroomName?: string;
+  scopes: string[];
+  active: boolean;
+  lastVerifiedAt?: Date | null;
+  lastVerificationStatus?: string;
+  lastVerificationError?: string;
+  lastUserCount?: number;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+interface RewardIntegrationConfig extends PublicRewardIntegrationInstance {
+  apiKey: string;
+}
+
+export interface RewardIntegrationInstanceInput {
+  name?: string;
+  description?: string;
+  apiBaseUrl?: string;
+  apiKey?: string;
+  classroomId?: string;
+  classroomName?: string;
+  scopes?: string[];
+  active?: boolean;
+}
+
+export interface RewardIntegrationTestResult {
+  classroomId: string;
+  classroomName?: string;
+  userCount: number;
+  verifiedAt: Date;
+}
+
+export interface PrizeversityLinkedAccount {
+  instanceId?: string;
+  userId: string;
+  classroomId: string;
+  email?: string;
+  matchedName?: string;
+  shortId?: string;
+  linkedAt?: Date | null;
+  lastSyncedAt?: Date | null;
+}
+
+export interface PrizeversityStatus {
+  configured: boolean;
+  linked: boolean;
+  missingConfig: string[];
+  account: PrizeversityLinkedAccount | null;
+  instances: PublicRewardIntegrationInstance[];
+}
+
+interface PrizeversityUserListResponse {
+  classroomId: string;
+  className?: string;
+  users?: PrizeversityClassroomUser[];
+}
+
+interface PrizeversityClassroomUser {
+  userId: string;
+  shortId?: string;
+  name?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  role?: string;
+}
+
+interface PrizeversityUsersMatchResponse {
+  matched?: PrizeversityMatchedUser[];
+  unmatched?: Array<Record<string, unknown>>;
+  total?: number;
+}
+
+interface PrizeversityMatchedUser {
+  userId: string;
+  matchedName?: string;
+  email?: string;
+  name?: string;
+  shortId?: string;
+  [key: string]: unknown;
+}
+
+export interface PrizeversityRewardRequest {
+  awsUserId: string | Types.ObjectId;
+  prizeversityUserId: string;
+  rewardIntegrationInstanceId?: string;
+  classroomId?: string;
+  challengeKey: string;
+  activityName: string;
+  description?: string;
+  bits?: number;
+  stats?: {
+    multiplier?: number;
+    luck?: number;
+    discount?: number;
+    shield?: number;
+  };
+  completionXP?: {
+    mode?: 'none' | 'classroom' | 'custom';
+    xpAmount?: number;
+  };
+  applyGroupMultipliers?: boolean;
+  applyPersonalMultipliers?: boolean;
+}
+
+export interface PrizeversityRewardResult {
+  alreadySent: boolean;
+  response: Record<string, unknown> | null;
+}
+
+class PrizeversityError extends Error {
+  status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'PrizeversityError';
+    this.status = status;
+  }
+}
+
+const cleanPastedValue = (value?: string | null): string => {
+  return (value || '')
+    .trim()
+    .replace(/^["'`]+|["'`]+$/g, '')
+    .trim();
+};
+
+const getApiKeyPreview = (apiKey: string): string => {
+  const trimmed = cleanPastedValue(apiKey);
+  if (trimmed.length <= 12) return 'provided';
+  return `${trimmed.slice(0, 8)}...${trimmed.slice(-4)}`;
+};
+
+const normalizeBaseUrl = (value?: string): string => {
+  const rawValue = cleanPastedValue(
+    value || env.PRIZEVERSITY_API_URL || DEFAULT_API_BASE_URL
+  ).replace(/\/+$/, '');
+
+  try {
+    const url = new URL(rawValue);
+    url.pathname = url.pathname.replace(/\/api\/integrations(?:\/.*)?$/i, '').replace(/\/+$/, '');
+    url.search = '';
+    url.hash = '';
+    return url.toString().replace(/\/+$/, '');
+  } catch {
+    return rawValue.replace(/\/api\/integrations(?:\/.*)?$/i, '').replace(/\/+$/, '');
+  }
+};
+
+const normalizeScopes = (scopes?: string[]): string[] => {
+  const normalized = (scopes || []).map(cleanPastedValue).filter(Boolean);
+  return normalized.length ? normalized : DEFAULT_SCOPES;
+};
+
+export const getPrizeversityMissingConfig = (): string[] => {
+  const missing: string[] = [];
+  if (!env.PRIZEVERSITY_API_URL) missing.push('PRIZEVERSITY_API_URL');
+  if (!env.PRIZEVERSITY_API_KEY) missing.push('PRIZEVERSITY_API_KEY');
+  if (!env.PRIZEVERSITY_CLASSROOM_ID) missing.push('PRIZEVERSITY_CLASSROOM_ID');
+  return missing;
+};
+
+export const isPrizeversityConfigured = (): boolean => getPrizeversityMissingConfig().length === 0;
+
+const normalize = (value?: string | null): string => (value || '').trim().toLowerCase();
+
+const uniqueStrings = (values: Array<string | undefined | null>): string[] => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  values.forEach((value) => {
+    const trimmed = value?.trim();
+    const key = normalize(trimmed);
+    if (!trimmed || seen.has(key)) return;
+    seen.add(key);
+    result.push(trimmed);
+  });
+
+  return result;
+};
+
+const getUserDisplayName = (user: IUserDocument): string => {
+  return user.fullName || user.username || user.email;
+};
+
+const getCandidateIdentifiers = (user: IUserDocument, identifier?: string): string[] => {
+  return uniqueStrings([identifier, user.email, user.fullName, user.username]);
+};
+
+const getEnvironmentInstance = (): RewardIntegrationConfig | null => {
+  if (!isPrizeversityConfigured()) return null;
+
+  const apiKey = cleanPastedValue(env.PRIZEVERSITY_API_KEY);
+  const classroomId = cleanPastedValue(env.PRIZEVERSITY_CLASSROOM_ID);
+
+  return {
+    id: 'env',
+    source: 'environment',
+    provider: DEFAULT_PROVIDER,
+    name: 'Default Prizeversity Classroom',
+    description: 'Configured from backend environment variables.',
+    apiBaseUrl: normalizeBaseUrl(env.PRIZEVERSITY_API_URL),
+    apiKey,
+    apiKeyPreview: getApiKeyPreview(apiKey),
+    classroomId,
+    classroomName: '',
+    scopes: DEFAULT_SCOPES,
+    active: true,
+    lastVerificationStatus: 'untested',
+  };
+};
+
+const toPublicInstance = (
+  instance: IRewardIntegrationInstanceDocument
+): PublicRewardIntegrationInstance => {
+  return {
+    id: String(instance._id),
+    source: 'database',
+    provider: instance.provider,
+    name: instance.name,
+    description: instance.description,
+    apiBaseUrl: instance.apiBaseUrl,
+    apiKeyPreview: instance.apiKeyPreview,
+    classroomId: instance.classroomId,
+    classroomName: instance.classroomName,
+    scopes: instance.scopes || [],
+    active: instance.active,
+    lastVerifiedAt: instance.lastVerifiedAt,
+    lastVerificationStatus: instance.lastVerificationStatus,
+    lastVerificationError: instance.lastVerificationError,
+    lastUserCount: instance.lastUserCount,
+    createdAt: instance.createdAt,
+    updatedAt: instance.updatedAt,
+  };
+};
+
+const toConfig = (instance: IRewardIntegrationInstanceDocument): RewardIntegrationConfig => {
+  return {
+    ...toPublicInstance(instance),
+    apiKey: instance.apiKey,
+  };
+};
+
+const prizeversityRequest = async <T>(
+  config: Pick<RewardIntegrationConfig, 'apiBaseUrl' | 'apiKey'>,
+  path: string,
+  options: RequestInit = {}
+): Promise<T> => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${normalizeBaseUrl(config.apiBaseUrl)}${path}`, {
+      ...options,
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': config.apiKey,
+        ...(options.headers || {}),
+      },
+    });
+
+    const contentType = response.headers.get('content-type') || '';
+    const data = contentType.includes('application/json')
+      ? ((await response.json()) as Record<string, unknown>)
+      : ({ message: await response.text() } as Record<string, unknown>);
+
+    if (!response.ok) {
+      const message =
+        typeof data.error === 'string'
+          ? data.error
+          : typeof data.message === 'string'
+            ? data.message
+            : `Prizeversity request failed with status ${response.status}`;
+      throw new PrizeversityError(message, response.status);
+    }
+
+    return data as T;
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new PrizeversityError('Prizeversity request timed out');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const usersMatch = async (
+  config: RewardIntegrationConfig,
+  identifiers: string[],
+  user: IUserDocument
+): Promise<PrizeversityMatchedUser | null> => {
+  const response = await prizeversityRequest<PrizeversityUsersMatchResponse>(
+    config,
+    '/api/integrations/users/match',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        classroomId: config.classroomId,
+        users: identifiers.map((identifier, index) => ({
+          name: identifier,
+          email: user.email,
+          awsUserId: String(user._id),
+          candidateIndex: index,
+        })),
+      }),
+    }
+  );
+
+  return response.matched?.[0] || null;
+};
+
+const usersList = async (
+  config: RewardIntegrationConfig
+): Promise<PrizeversityUserListResponse> => {
+  const classroomId = encodeURIComponent(cleanPastedValue(config.classroomId));
+
+  return prizeversityRequest<PrizeversityUserListResponse>(
+    config,
+    `/api/integrations/users/list/${classroomId}?fields=extended`
+  );
+};
+
+const findExactUser = (
+  users: PrizeversityClassroomUser[],
+  identifiers: string[]
+): PrizeversityClassroomUser | null => {
+  const normalizedIdentifiers = identifiers.map(normalize);
+
+  return (
+    users.find((candidate) => {
+      const fullName =
+        candidate.name || `${candidate.firstName || ''} ${candidate.lastName || ''}`.trim();
+      const searchableValues = [candidate.userId, candidate.shortId, candidate.email, fullName].map(
+        normalize
+      );
+
+      return searchableValues.some((value) => value && normalizedIdentifiers.includes(value));
+    }) || null
+  );
+};
+
+const toLinkedAccount = (
+  user: PrizeversityClassroomUser | PrizeversityMatchedUser,
+  config: RewardIntegrationConfig
+): PrizeversityLinkedAccount => {
+  return {
+    instanceId: config.id,
+    userId: String(user.userId),
+    classroomId: config.classroomId,
+    email: user.email,
+    matchedName:
+      'matchedName' in user && typeof user.matchedName === 'string' ? user.matchedName : user.name,
+    shortId: user.shortId,
+  };
+};
+
+export const listRewardIntegrationInstances = async (): Promise<
+  PublicRewardIntegrationInstance[]
+> => {
+  const instances = await RewardIntegrationInstance.find().sort({ createdAt: -1 });
+  return instances.map(toPublicInstance);
+};
+
+export const listActiveRewardIntegrationInstances = async (): Promise<
+  PublicRewardIntegrationInstance[]
+> => {
+  const instances = await RewardIntegrationInstance.find({ active: true }).sort({ createdAt: 1 });
+  const publicInstances = instances.map(toPublicInstance);
+
+  if (publicInstances.length === 0) {
+    const envInstance = getEnvironmentInstance();
+    if (envInstance) {
+      const { apiKey: _apiKey, ...publicEnvInstance } = envInstance;
+      publicInstances.push(publicEnvInstance);
+    }
+  }
+
+  return publicInstances;
+};
+
+const getInstanceConfigById = async (
+  instanceId?: string
+): Promise<RewardIntegrationConfig | null> => {
+  if (instanceId === 'env') {
+    return getEnvironmentInstance();
+  }
+
+  if (instanceId) {
+    if (!Types.ObjectId.isValid(instanceId)) return null;
+    const instance = await RewardIntegrationInstance.findOne({
+      _id: instanceId,
+      active: true,
+    }).select('+apiKey');
+    return instance ? toConfig(instance) : null;
+  }
+
+  const instance = await RewardIntegrationInstance.findOne({ active: true })
+    .sort({ createdAt: 1 })
+    .select('+apiKey');
+
+  if (instance) return toConfig(instance);
+  return getEnvironmentInstance();
+};
+
+const getInstanceConfigForClassroom = async (
+  classroomId?: string,
+  instanceId?: string
+): Promise<RewardIntegrationConfig | null> => {
+  const explicitInstance = await getInstanceConfigById(instanceId);
+  if (explicitInstance) return explicitInstance;
+
+  if (classroomId) {
+    const instance = await RewardIntegrationInstance.findOne({
+      classroomId,
+      active: true,
+    }).select('+apiKey');
+    if (instance) return toConfig(instance);
+
+    const envInstance = getEnvironmentInstance();
+    if (envInstance?.classroomId === classroomId) return envInstance;
+  }
+
+  return getInstanceConfigById();
+};
+
+export const getPrizeversityStatus = async (
+  user: IUserDocument | null
+): Promise<PrizeversityStatus> => {
+  const instances = await listActiveRewardIntegrationInstances();
+  const missingConfig = instances.length > 0 ? [] : getPrizeversityMissingConfig();
+  const account =
+    user?.prizeversityUserId && user.prizeversityClassroomId
+      ? {
+          instanceId:
+            user.rewardIntegrationInstanceId?.toString() ||
+            instances.find((instance) => instance.classroomId === user.prizeversityClassroomId)?.id,
+          userId: user.prizeversityUserId,
+          classroomId: user.prizeversityClassroomId,
+          email: user.prizeversityEmail,
+          matchedName: user.prizeversityMatchedName,
+          shortId: user.prizeversityShortId,
+          linkedAt: user.prizeversityLinkedAt,
+          lastSyncedAt: user.prizeversityLastSyncedAt,
+        }
+      : null;
+
+  return {
+    configured: instances.length > 0,
+    linked: Boolean(account),
+    missingConfig,
+    account,
+    instances,
+  };
+};
+
+export const testRewardIntegrationConfig = async (
+  config: RewardIntegrationConfig
+): Promise<RewardIntegrationTestResult> => {
+  const response = await usersList(config);
+  const verifiedAt = new Date();
+
+  return {
+    classroomId: response.classroomId || config.classroomId,
+    classroomName: response.className,
+    userCount: response.users?.length || 0,
+    verifiedAt,
+  };
+};
+
+export const createRewardIntegrationInstance = async (
+  input: RewardIntegrationInstanceInput,
+  adminUserId: string
+): Promise<PublicRewardIntegrationInstance> => {
+  const name = cleanPastedValue(input.name);
+  const apiKey = cleanPastedValue(input.apiKey);
+  const classroomId = cleanPastedValue(input.classroomId);
+
+  if (!name) throw new PrizeversityError('Instance name is required.');
+  if (!apiKey) throw new PrizeversityError('Prizeversity API key is required.');
+  if (!classroomId) throw new PrizeversityError('Prizeversity classroom ID is required.');
+
+  const apiBaseUrl = normalizeBaseUrl(input.apiBaseUrl);
+  const config: RewardIntegrationConfig = {
+    id: 'new',
+    source: 'database',
+    provider: DEFAULT_PROVIDER,
+    name,
+    description: cleanPastedValue(input.description),
+    apiBaseUrl,
+    apiKey,
+    apiKeyPreview: getApiKeyPreview(apiKey),
+    classroomId,
+    classroomName: cleanPastedValue(input.classroomName),
+    scopes: normalizeScopes(input.scopes),
+    active: input.active ?? true,
+  };
+
+  const testResult = await testRewardIntegrationConfig(config);
+
+  const instance = await RewardIntegrationInstance.create({
+    name,
+    description: config.description,
+    provider: DEFAULT_PROVIDER,
+    apiBaseUrl,
+    apiKey,
+    apiKeyPreview: config.apiKeyPreview,
+    classroomId,
+    classroomName: testResult.classroomName || config.classroomName,
+    scopes: config.scopes,
+    active: config.active,
+    lastVerifiedAt: testResult.verifiedAt,
+    lastVerificationStatus: 'verified',
+    lastVerificationError: undefined,
+    lastUserCount: testResult.userCount,
+    createdBy: new Types.ObjectId(adminUserId),
+  });
+
+  return toPublicInstance(instance);
+};
+
+export const updateRewardIntegrationInstance = async (
+  instanceId: string,
+  input: RewardIntegrationInstanceInput,
+  adminUserId: string
+): Promise<PublicRewardIntegrationInstance> => {
+  if (!Types.ObjectId.isValid(instanceId)) {
+    throw new PrizeversityError('Invalid integration instance ID.');
+  }
+
+  const instance = await RewardIntegrationInstance.findById(instanceId).select('+apiKey');
+  if (!instance) throw new PrizeversityError('Integration instance not found.');
+
+  const nextApiBaseUrl = input.apiBaseUrl
+    ? normalizeBaseUrl(input.apiBaseUrl)
+    : instance.apiBaseUrl;
+  const nextApiKey = cleanPastedValue(input.apiKey) || instance.apiKey;
+  const nextClassroomId = cleanPastedValue(input.classroomId) || instance.classroomId;
+  const shouldRetest =
+    nextApiBaseUrl !== instance.apiBaseUrl ||
+    nextApiKey !== instance.apiKey ||
+    nextClassroomId !== instance.classroomId;
+
+  if (input.name !== undefined) instance.name = cleanPastedValue(input.name);
+  if (input.description !== undefined) instance.description = cleanPastedValue(input.description);
+  if (input.apiBaseUrl !== undefined) instance.apiBaseUrl = nextApiBaseUrl;
+  if (input.apiKey !== undefined && cleanPastedValue(input.apiKey)) {
+    instance.apiKey = nextApiKey;
+    instance.apiKeyPreview = getApiKeyPreview(nextApiKey);
+  }
+  if (input.classroomId !== undefined) instance.classroomId = nextClassroomId;
+  if (input.classroomName !== undefined)
+    instance.classroomName = cleanPastedValue(input.classroomName);
+  if (input.scopes !== undefined) instance.scopes = normalizeScopes(input.scopes);
+  if (input.active !== undefined) instance.active = input.active;
+  instance.updatedBy = new Types.ObjectId(adminUserId);
+
+  if (shouldRetest) {
+    const testResult = await testRewardIntegrationConfig({
+      ...toConfig(instance),
+      apiBaseUrl: nextApiBaseUrl,
+      apiKey: nextApiKey,
+      classroomId: nextClassroomId,
+    });
+    instance.classroomName = testResult.classroomName || instance.classroomName;
+    instance.lastVerifiedAt = testResult.verifiedAt;
+    instance.lastVerificationStatus = 'verified';
+    instance.lastVerificationError = undefined;
+    instance.lastUserCount = testResult.userCount;
+  }
+
+  await instance.save();
+  return toPublicInstance(instance);
+};
+
+export const testRewardIntegrationInstance = async (
+  instanceId: string,
+  adminUserId: string
+): Promise<{ instance: PublicRewardIntegrationInstance; test: RewardIntegrationTestResult }> => {
+  if (!Types.ObjectId.isValid(instanceId)) {
+    throw new PrizeversityError('Invalid integration instance ID.');
+  }
+
+  const instance = await RewardIntegrationInstance.findById(instanceId).select('+apiKey');
+  if (!instance) throw new PrizeversityError('Integration instance not found.');
+
+  try {
+    const test = await testRewardIntegrationConfig(toConfig(instance));
+    instance.classroomName = test.classroomName || instance.classroomName;
+    instance.lastVerifiedAt = test.verifiedAt;
+    instance.lastVerificationStatus = 'verified';
+    instance.lastVerificationError = undefined;
+    instance.lastUserCount = test.userCount;
+    instance.updatedBy = new Types.ObjectId(adminUserId);
+    await instance.save();
+
+    return { instance: toPublicInstance(instance), test };
+  } catch (error: unknown) {
+    instance.lastVerifiedAt = new Date();
+    instance.lastVerificationStatus = 'failed';
+    instance.lastVerificationError =
+      error instanceof Error ? error.message : 'Integration test failed.';
+    instance.updatedBy = new Types.ObjectId(adminUserId);
+    await instance.save();
+    throw error;
+  }
+};
+
+export const deactivateRewardIntegrationInstance = async (
+  instanceId: string,
+  adminUserId: string
+): Promise<PublicRewardIntegrationInstance> => {
+  return updateRewardIntegrationInstance(instanceId, { active: false }, adminUserId);
+};
+
+export const linkPrizeversityAccount = async (
+  user: IUserDocument,
+  options: { identifier?: string; instanceId?: string } = {}
+): Promise<PrizeversityLinkedAccount> => {
+  const config = await getInstanceConfigById(options.instanceId);
+  if (!config) {
+    throw new PrizeversityError('No active Prizeversity reward integration is configured.');
+  }
+
+  const identifiers = getCandidateIdentifiers(user, options.identifier);
+  let matchedAccount: PrizeversityLinkedAccount | null = null;
+
+  try {
+    const classroomUsers = await usersList(config);
+    const exactUser = findExactUser(classroomUsers.users || [], identifiers);
+    if (exactUser) {
+      matchedAccount = toLinkedAccount(exactUser, config);
+    }
+  } catch (error: unknown) {
+    log.warn('prizeversity users/list lookup failed; falling back to users/match.', {
+      error: error instanceof Error ? error.message : error,
+      userId: String(user._id),
+      instanceId: config.id,
+    });
+  }
+
+  if (!matchedAccount) {
+    const matchedUser = await usersMatch(config, identifiers, user);
+    if (matchedUser) {
+      matchedAccount = toLinkedAccount(matchedUser, config);
+    }
+  }
+
+  if (!matchedAccount) {
+    throw new PrizeversityError(
+      `No Prizeversity classroom member matched ${options.identifier || getUserDisplayName(user)}.`
+    );
+  }
+
+  const now = new Date();
+  user.rewardIntegrationInstanceId =
+    config.source === 'database' ? new Types.ObjectId(config.id) : null;
+  user.prizeversityUserId = matchedAccount.userId;
+  user.prizeversityClassroomId = matchedAccount.classroomId;
+  user.prizeversityEmail = matchedAccount.email;
+  user.prizeversityMatchedName = matchedAccount.matchedName;
+  user.prizeversityShortId = matchedAccount.shortId;
+  user.prizeversityLinkedAt = user.prizeversityLinkedAt || now;
+  user.prizeversityLastSyncedAt = now;
+  await user.save();
+
+  return {
+    ...matchedAccount,
+    linkedAt: user.prizeversityLinkedAt,
+    lastSyncedAt: user.prizeversityLastSyncedAt,
+  };
+};
+
+export const unlinkPrizeversityAccount = async (user: IUserDocument): Promise<void> => {
+  user.rewardIntegrationInstanceId = null;
+  user.prizeversityUserId = undefined;
+  user.prizeversityClassroomId = undefined;
+  user.prizeversityEmail = undefined;
+  user.prizeversityMatchedName = undefined;
+  user.prizeversityShortId = undefined;
+  user.prizeversityLinkedAt = null;
+  user.prizeversityLastSyncedAt = null;
+  await user.save();
+};
+
+export const grantPrizeversityChallengeReward = async ({
+  awsUserId,
+  prizeversityUserId,
+  rewardIntegrationInstanceId,
+  classroomId,
+  challengeKey,
+  activityName,
+  description = '',
+  bits = 0,
+  stats = {},
+  completionXP = { mode: 'classroom' },
+  applyGroupMultipliers = true,
+  applyPersonalMultipliers = true,
+}: PrizeversityRewardRequest): Promise<PrizeversityRewardResult> => {
+  const config = await getInstanceConfigForClassroom(classroomId, rewardIntegrationInstanceId);
+  if (!config) {
+    throw new PrizeversityError('No active Prizeversity reward integration is configured.');
+  }
+
+  const awsUserObjectId = new Types.ObjectId(String(awsUserId));
+  const requestPayload = {
+    classroomId: config.classroomId,
+    userId: prizeversityUserId,
+    activityName,
+    description,
+    bits,
+    stats,
+    completionXP,
+    applyGroupMultipliers,
+    applyPersonalMultipliers,
+  };
+
+  const existing = await RewardIntegrationEmission.findOne({
+    awsUserId: awsUserObjectId,
+    classroomId: config.classroomId,
+    challengeKey,
+  });
+
+  if (existing?.status === 'sent') {
+    return {
+      alreadySent: true,
+      response: (existing.responsePayload as Record<string, unknown>) || null,
+    };
+  }
+
+  const emission =
+    existing ||
+    (await RewardIntegrationEmission.create({
+      awsUserId: awsUserObjectId,
+      prizeversityUserId,
+      classroomId: config.classroomId,
+      challengeKey,
+      activityName,
+      status: 'pending',
+      requestPayload,
+    }));
+
+  try {
+    const response = await prizeversityRequest<Record<string, unknown>>(
+      config,
+      '/api/integrations/reward',
+      {
+        method: 'POST',
+        body: JSON.stringify(requestPayload),
+      }
+    );
+
+    emission.status = 'sent';
+    emission.responsePayload = response;
+    emission.errorMessage = undefined;
+    emission.sentAt = new Date();
+    await emission.save();
+
+    return {
+      alreadySent: false,
+      response,
+    };
+  } catch (error: unknown) {
+    emission.status = 'failed';
+    emission.errorMessage = error instanceof Error ? error.message : 'Prizeversity reward failed';
+    await emission.save();
+    throw error;
+  }
+};

--- a/backend/src/services/rewardIntegrationService.ts
+++ b/backend/src/services/rewardIntegrationService.ts
@@ -1,16 +1,21 @@
+import crypto from 'crypto';
 import { Types } from 'mongoose';
 
 import env from '../config/env';
 import logger from '../config/logger';
 import RewardIntegrationEmission from '../models/RewardIntegrationEmission';
+import RewardIntegrationLinkVerification from '../models/RewardIntegrationLinkVerification';
 import RewardIntegrationInstance, {
   IRewardIntegrationInstanceDocument,
 } from '../models/RewardIntegrationInstance';
 import type { IUserDocument } from '../models/User';
+import { sendPrizeversityLinkCode } from './emailService';
 
 const log = logger.child({ module: 'reward-integration-service' });
 
 const REQUEST_TIMEOUT_MS = 12000;
+const LINK_CODE_TTL_MS = 10 * 60 * 1000;
+const MAX_LINK_CODE_ATTEMPTS = 5;
 const DEFAULT_PROVIDER = 'prizeversity';
 const DEFAULT_API_BASE_URL = 'https://www.prizeversity.com';
 const DEFAULT_SCOPES = ['users:read', 'users:match', 'reward:grant'];
@@ -74,6 +79,12 @@ export interface PrizeversityStatus {
   missingConfig: string[];
   account: PrizeversityLinkedAccount | null;
   instances: PublicRewardIntegrationInstance[];
+}
+
+export interface PrizeversityLinkVerificationStart {
+  verificationRequired: true;
+  maskedEmail: string;
+  expiresAt: Date;
 }
 
 interface PrizeversityUserListResponse {
@@ -177,6 +188,21 @@ const normalizeBaseUrl = (value?: string): string => {
 const normalizeScopes = (scopes?: string[]): string[] => {
   const normalized = (scopes || []).map(cleanPastedValue).filter(Boolean);
   return normalized.length ? normalized : DEFAULT_SCOPES;
+};
+
+const generateLinkCode = (): string => {
+  return crypto.randomInt(100000, 1000000).toString();
+};
+
+const hashLinkCode = (code: string, salt: string): string => {
+  return crypto.createHash('sha256').update(`${salt}:${code}`).digest('hex');
+};
+
+const maskEmail = (email: string): string => {
+  const [localPart, domain] = email.split('@');
+  if (!localPart || !domain) return email;
+  const visible = localPart.slice(0, Math.min(2, localPart.length));
+  return `${visible}${'*'.repeat(Math.max(localPart.length - visible.length, 3))}@${domain}`;
 };
 
 export const getPrizeversityMissingConfig = (): string[] => {
@@ -641,10 +667,10 @@ export const deactivateRewardIntegrationInstance = async (
   return updateRewardIntegrationInstance(instanceId, { active: false }, adminUserId);
 };
 
-export const linkPrizeversityAccount = async (
+const resolvePrizeversityAccount = async (
   user: IUserDocument,
   options: { identifier?: string; instanceId?: string } = {}
-): Promise<PrizeversityLinkedAccount> => {
+): Promise<{ config: RewardIntegrationConfig; matchedAccount: PrizeversityLinkedAccount }> => {
   const config = await getInstanceConfigById(options.instanceId);
   if (!config) {
     throw new PrizeversityError('No active Prizeversity reward integration is configured.');
@@ -680,9 +706,16 @@ export const linkPrizeversityAccount = async (
     );
   }
 
+  return { config, matchedAccount };
+};
+
+const applyPrizeversityLink = async (
+  user: IUserDocument,
+  matchedAccount: PrizeversityLinkedAccount,
+  rewardIntegrationInstanceId?: Types.ObjectId | null
+): Promise<PrizeversityLinkedAccount> => {
   const now = new Date();
-  user.rewardIntegrationInstanceId =
-    config.source === 'database' ? new Types.ObjectId(config.id) : null;
+  user.rewardIntegrationInstanceId = rewardIntegrationInstanceId || null;
   user.prizeversityUserId = matchedAccount.userId;
   user.prizeversityClassroomId = matchedAccount.classroomId;
   user.prizeversityEmail = matchedAccount.email;
@@ -699,7 +732,114 @@ export const linkPrizeversityAccount = async (
   };
 };
 
+export const startPrizeversityAccountLink = async (
+  user: IUserDocument,
+  options: { identifier?: string; instanceId?: string } = {}
+): Promise<PrizeversityLinkVerificationStart> => {
+  const { config, matchedAccount } = await resolvePrizeversityAccount(user, options);
+  const email = cleanPastedValue(matchedAccount.email).toLowerCase();
+
+  if (!email) {
+    throw new PrizeversityError(
+      'Matched Prizeversity account does not have an email address. Ask an admin to link your account.'
+    );
+  }
+
+  const code = generateLinkCode();
+  const codeSalt = crypto.randomBytes(16).toString('hex');
+  const expiresAt = new Date(Date.now() + LINK_CODE_TTL_MS);
+  const rewardIntegrationInstanceId =
+    config.source === 'database' ? new Types.ObjectId(config.id) : null;
+
+  await RewardIntegrationLinkVerification.findOneAndUpdate(
+    { awsUserId: user._id },
+    {
+      awsUserId: user._id,
+      rewardIntegrationInstanceId,
+      prizeversityUserId: matchedAccount.userId,
+      classroomId: matchedAccount.classroomId,
+      email,
+      matchedName: matchedAccount.matchedName,
+      shortId: matchedAccount.shortId,
+      codeHash: hashLinkCode(code, codeSalt),
+      codeSalt,
+      attempts: 0,
+      expiresAt,
+    },
+    { new: true, setDefaultsOnInsert: true, upsert: true }
+  );
+
+  await sendPrizeversityLinkCode(
+    email,
+    code,
+    matchedAccount.matchedName || user.fullName || 'there',
+    config.classroomName || config.name
+  );
+
+  return {
+    verificationRequired: true,
+    maskedEmail: maskEmail(email),
+    expiresAt,
+  };
+};
+
+export const verifyPrizeversityAccountLink = async (
+  user: IUserDocument,
+  code: string
+): Promise<PrizeversityLinkedAccount> => {
+  const cleanedCode = cleanPastedValue(code);
+  if (!cleanedCode) throw new PrizeversityError('Verification code is required.');
+
+  const pending = await RewardIntegrationLinkVerification.findOne({ awsUserId: user._id });
+  if (!pending) {
+    throw new PrizeversityError('No Prizeversity link code is pending. Request a new code.');
+  }
+
+  if (pending.expiresAt.getTime() <= Date.now()) {
+    await pending.deleteOne();
+    throw new PrizeversityError('Prizeversity link code expired. Request a new code.');
+  }
+
+  if (pending.attempts >= MAX_LINK_CODE_ATTEMPTS) {
+    await pending.deleteOne();
+    throw new PrizeversityError('Too many incorrect codes. Request a new code.');
+  }
+
+  const expectedHash = hashLinkCode(cleanedCode, pending.codeSalt);
+  if (expectedHash !== pending.codeHash) {
+    pending.attempts += 1;
+    await pending.save();
+    throw new PrizeversityError('Invalid Prizeversity link code.');
+  }
+
+  const account = await applyPrizeversityLink(
+    user,
+    {
+      userId: pending.prizeversityUserId,
+      classroomId: pending.classroomId,
+      email: pending.email,
+      matchedName: pending.matchedName,
+      shortId: pending.shortId,
+    },
+    pending.rewardIntegrationInstanceId || null
+  );
+
+  await pending.deleteOne();
+  return account;
+};
+
+export const linkPrizeversityAccount = async (
+  user: IUserDocument,
+  options: { identifier?: string; instanceId?: string } = {}
+): Promise<PrizeversityLinkedAccount> => {
+  const { config, matchedAccount } = await resolvePrizeversityAccount(user, options);
+  const rewardIntegrationInstanceId =
+    config.source === 'database' ? new Types.ObjectId(config.id) : null;
+  return applyPrizeversityLink(user, matchedAccount, rewardIntegrationInstanceId);
+};
+
 export const unlinkPrizeversityAccount = async (user: IUserDocument): Promise<void> => {
+  await RewardIntegrationLinkVerification.deleteOne({ awsUserId: user._id });
   user.rewardIntegrationInstanceId = null;
   user.prizeversityUserId = undefined;
   user.prizeversityClassroomId = undefined;

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -191,6 +191,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         const data = await response.json();
 
         // Update stored tokens using appropriate storage
+        localStorage.setItem('rememberMe', data.rememberMe ? 'true' : 'false');
         setStoredItem('accessToken', data.accessToken);
         setStoredItem('refreshToken', data.refreshToken);
         setStoredItem('cachedUser', JSON.stringify(data.user));

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -134,6 +134,12 @@ function Account({ theme: _theme }: AccountProps) {
   const [prizeversityIdentifier, setPrizeversityIdentifier] = useState<string>('');
   const [selectedRewardInstanceId, setSelectedRewardInstanceId] = useState<string>('');
   const [isPrizeversityLoading, setIsPrizeversityLoading] = useState<boolean>(false);
+  const [prizeversityLinkError, setPrizeversityLinkError] = useState<string>('');
+  const [prizeversityVerification, setPrizeversityVerification] = useState<{
+    maskedEmail: string;
+    expiresAt?: string;
+  } | null>(null);
+  const [prizeversityVerificationCode, setPrizeversityVerificationCode] = useState<string>('');
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const inputRefs = useRef<Partial<Record<AccountField, AccountInputElement | null>>>({});
 
@@ -150,6 +156,8 @@ function Account({ theme: _theme }: AccountProps) {
   const isAuthenticated = isAuth0Authenticated || !!authUser;
   const currentUser = (auth0User || authUser) as AccountUser | undefined;
   const isSocialLogin = !!auth0User;
+  const isPrizeversityLinked = Boolean(prizeversityStatus?.linked && prizeversityStatus.account);
+  const isPrizeversityGateLoading = isPrizeversityLoading && !prizeversityStatus;
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -211,6 +219,16 @@ function Account({ theme: _theme }: AccountProps) {
 
   // Scroll to top when component mounts
   useEffect(() => {
+    if (window.location.hash === '#prizeversity-rewards') {
+      setTimeout(() => {
+        document.getElementById('prizeversity-rewards')?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      }, 100);
+      return;
+    }
+
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }, []);
 
@@ -231,6 +249,14 @@ function Account({ theme: _theme }: AccountProps) {
         }) as AccountFormData
     );
     setError('');
+  };
+
+  const focusPrizeversityLinking = () => {
+    document.getElementById('prizeversity-rewards')?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+    });
+    setError('Link your Prizeversity account before starting AWS challenges.');
   };
 
   const handleLanguageToggle = (language: string) => {
@@ -458,6 +484,12 @@ function Account({ theme: _theme }: AccountProps) {
 
   const handleRevealCredentials = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (!isPrizeversityLinked) {
+      setShowCredentialsModal(false);
+      focusPrizeversityLinking();
+      return;
+    }
+
     if (!credentialsPassword) {
       setError('Password is required');
       return;
@@ -482,15 +514,21 @@ function Account({ theme: _theme }: AccountProps) {
   };
 
   const handleShowCyberModal = () => {
-    if (currentUser?.awsAccessKeyId && currentUser?.awsSecretAccessKey) {
+    if (!isPrizeversityLinked) {
+      focusPrizeversityLinking();
+      return;
+    }
+
+    if (awsCredentials || (currentUser?.awsAccessKeyId && currentUser?.awsSecretAccessKey)) {
       setShowCyberModal(true);
     } else {
-      setError('No AWS credentials found for your account');
+      setError('Reveal your AWS credentials before opening the challenge instructions.');
     }
   };
 
   const handlePrizeversityLink = async () => {
     setIsPrizeversityLoading(true);
+    setPrizeversityLinkError('');
     setError('');
     setSuccess('');
 
@@ -499,16 +537,46 @@ function Account({ theme: _theme }: AccountProps) {
         prizeversityIdentifier,
         selectedRewardInstanceId
       );
+      if (response.verificationRequired && response.maskedEmail) {
+        setPrizeversityVerification({
+          maskedEmail: response.maskedEmail,
+          expiresAt: response.expiresAt,
+        });
+        setPrizeversityVerificationCode('');
+      }
+      setSuccess(response.message);
+      setTimeout(() => setSuccess(''), 4000);
+    } catch (err) {
+      const message = getErrorMessage(err, 'Failed to link Prizeversity account');
+      setPrizeversityLinkError(message);
+      setError(message);
+    } finally {
+      setIsPrizeversityLoading(false);
+    }
+  };
+
+  const handlePrizeversityVerify = async () => {
+    setIsPrizeversityLoading(true);
+    setPrizeversityLinkError('');
+    setError('');
+    setSuccess('');
+
+    try {
+      const response = await rewardIntegrationAPI.verifyLink(prizeversityVerificationCode);
       setPrizeversityStatus(response.status);
       setPrizeversityIdentifier(response.status.account?.email || prizeversityIdentifier);
       setSelectedRewardInstanceId(
         response.status.account?.instanceId || response.status.instances?.[0]?.id || ''
       );
+      setPrizeversityVerification(null);
+      setPrizeversityVerificationCode('');
       await refreshTokens();
       setSuccess(response.message);
       setTimeout(() => setSuccess(''), 4000);
     } catch (err) {
-      setError(getErrorMessage(err, 'Failed to link Prizeversity account'));
+      const message = getErrorMessage(err, 'Failed to verify Prizeversity link code');
+      setPrizeversityLinkError(message);
+      setError(message);
     } finally {
       setIsPrizeversityLoading(false);
     }
@@ -516,6 +584,9 @@ function Account({ theme: _theme }: AccountProps) {
 
   const handlePrizeversityUnlink = async () => {
     setIsPrizeversityLoading(true);
+    setPrizeversityLinkError('');
+    setPrizeversityVerification(null);
+    setPrizeversityVerificationCode('');
     setError('');
     setSuccess('');
 
@@ -946,6 +1017,7 @@ function Account({ theme: _theme }: AccountProps) {
           </motion.section>
 
           <motion.section
+            id="prizeversity-rewards"
             className="prizeversity-section"
             initial={{ opacity: 0, y: 30 }}
             animate={{ opacity: 1, y: 0 }}
@@ -1046,7 +1118,12 @@ function Account({ theme: _theme }: AccountProps) {
                         id="prizeversity-identifier"
                         type="text"
                         value={prizeversityIdentifier}
-                        onChange={(event) => setPrizeversityIdentifier(event.target.value)}
+                        onChange={(event) => {
+                          setPrizeversityIdentifier(event.target.value);
+                          setPrizeversityLinkError('');
+                          setPrizeversityVerification(null);
+                          setPrizeversityVerificationCode('');
+                        }}
                         placeholder={currentUser?.email || 'email@example.com'}
                         disabled={isPrizeversityLoading}
                       />
@@ -1063,11 +1140,66 @@ function Account({ theme: _theme }: AccountProps) {
                         ) : (
                           <>
                             <RefreshCw size={16} aria-hidden="true" />
-                            {prizeversityStatus?.linked ? 'Re-sync' : 'Link account'}
+                            {prizeversityVerification
+                              ? 'Resend code'
+                              : prizeversityStatus?.linked
+                                ? 'Re-sync'
+                                : 'Send code'}
                           </>
                         )}
                       </button>
                     </div>
+                    {prizeversityVerification && (
+                      <div className="prizeversity-verification-panel">
+                        <div>
+                          <strong>Check your Prizeversity email.</strong>
+                          <span>
+                            We sent a one-time code to {prizeversityVerification.maskedEmail}. Enter
+                            it below to finish linking this account.
+                          </span>
+                        </div>
+                        <div className="prizeversity-code-row">
+                          <input
+                            type="text"
+                            inputMode="numeric"
+                            maxLength={6}
+                            value={prizeversityVerificationCode}
+                            onChange={(event) => {
+                              setPrizeversityVerificationCode(event.target.value);
+                              setPrizeversityLinkError('');
+                            }}
+                            placeholder="123456"
+                            disabled={isPrizeversityLoading}
+                          />
+                          <button
+                            type="button"
+                            className="show-modal-btn"
+                            onClick={handlePrizeversityVerify}
+                            disabled={
+                              isPrizeversityLoading ||
+                              prizeversityVerificationCode.trim().length < 6
+                            }
+                          >
+                            Verify code
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                    {prizeversityLinkError && (
+                      <div className="prizeversity-link-error" role="alert">
+                        <strong>
+                          {prizeversityVerification
+                            ? 'Verification failed.'
+                            : 'No Prizeversity match found.'}
+                        </strong>
+                        <span>{prizeversityLinkError}</span>
+                        <small>
+                          {prizeversityVerification
+                            ? 'Check the code from your email, or resend a new code if it expired.'
+                            : 'Confirm you selected the right reward classroom and try your Prizeversity email, full name, or short ID.'}
+                        </small>
+                      </div>
+                    )}
                   </div>
 
                   {prizeversityStatus?.linked && (
@@ -1128,7 +1260,29 @@ function Account({ theme: _theme }: AccountProps) {
                 </div>
               </div>
 
-              {currentUser?.awsAccessKeyId ? (
+              {isPrizeversityGateLoading ? (
+                <div className="no-credentials-message">
+                  <p>Checking Prizeversity reward link...</p>
+                </div>
+              ) : !isPrizeversityLinked ? (
+                <div className="account-challenge-gate">
+                  <div>
+                    <span>Prizeversity required</span>
+                    <h4>Link your reward account before starting this challenge.</h4>
+                    <p>
+                      AWS challenge completions are rewarded through Prizeversity, so we need to
+                      verify your classroom account before revealing challenge credentials.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="show-modal-btn"
+                    onClick={focusPrizeversityLinking}
+                  >
+                    <Link2 size={16} aria-hidden="true" /> Link Prizeversity
+                  </button>
+                </div>
+              ) : (
                 <div className="account-credentials-section">
                   {!awsCredentials ? (
                     <div className="account-challenge-actions">
@@ -1139,15 +1293,6 @@ function Account({ theme: _theme }: AccountProps) {
                         whileTap={{ scale: 0.98 }}
                       >
                         <Lock size={16} aria-hidden="true" /> Reveal credentials
-                      </motion.button>
-
-                      <motion.button
-                        className="show-modal-btn"
-                        onClick={handleShowCyberModal}
-                        whileHover={{ y: -2 }}
-                        whileTap={{ scale: 0.98 }}
-                      >
-                        <Target size={16} aria-hidden="true" /> Open instructions
                       </motion.button>
                     </div>
                   ) : (
@@ -1205,10 +1350,6 @@ function Account({ theme: _theme }: AccountProps) {
                       </div>
                     </div>
                   )}
-                </div>
-              ) : (
-                <div className="no-credentials-message">
-                  <p>AWS credentials not available for this account.</p>
                 </div>
               )}
             </div>

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -6,9 +6,11 @@ import { useAuth0 } from '@auth0/auth0-react';
 import { useAuth } from '../context/AuthContext';
 import './styles/Account.css';
 import { validateImageFile, compressImage } from '../utils/imageUtils';
-import { Copy, Lock, Shield, Target, X } from 'lucide-react';
+import { Copy, Link2, Lock, RefreshCw, Shield, Target, Unlink, X } from 'lucide-react';
 import CyberChallengeModal from '../components/CyberChallengeModal';
+import { rewardIntegrationAPI } from '../utils/api';
 import type { AwsCredentials } from '../types/auth';
+import type { RewardIntegrationStatusResponse } from '../types/rewardIntegration';
 import type { User } from '../types/user';
 import type { Theme } from '../types/ui';
 
@@ -127,12 +129,23 @@ function Account({ theme: _theme }: AccountProps) {
   const [credentialsPassword, setCredentialsPassword] = useState<string>('');
   const [isLoadingCredentials, setIsLoadingCredentials] = useState<boolean>(false);
   const [showCyberModal, setShowCyberModal] = useState<boolean>(false);
+  const [prizeversityStatus, setPrizeversityStatus] =
+    useState<RewardIntegrationStatusResponse | null>(null);
+  const [prizeversityIdentifier, setPrizeversityIdentifier] = useState<string>('');
+  const [selectedRewardInstanceId, setSelectedRewardInstanceId] = useState<string>('');
+  const [isPrizeversityLoading, setIsPrizeversityLoading] = useState<boolean>(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const inputRefs = useRef<Partial<Record<AccountField, AccountInputElement | null>>>({});
 
   const navigate = useNavigate();
   const { isAuthenticated: isAuth0Authenticated, user: auth0User } = useAuth0();
-  const { user: authUser, updateUser, uploadProfilePicture, getAwsCredentials } = useAuth();
+  const {
+    user: authUser,
+    updateUser,
+    uploadProfilePicture,
+    getAwsCredentials,
+    refreshTokens,
+  } = useAuth();
 
   const isAuthenticated = isAuth0Authenticated || !!authUser;
   const currentUser = (auth0User || authUser) as AccountUser | undefined;
@@ -160,6 +173,41 @@ function Account({ theme: _theme }: AccountProps) {
       setProfileImage(currentUser.picture || currentUser.profilePicture || '/avatar.jpg');
     }
   }, [isAuthenticated, currentUser, navigate]);
+
+  useEffect(() => {
+    if (!isAuthenticated || !getStoredItem('accessToken')) {
+      return;
+    }
+
+    let shouldUpdate = true;
+    setIsPrizeversityLoading(true);
+
+    rewardIntegrationAPI
+      .status()
+      .then((status) => {
+        if (shouldUpdate) {
+          setPrizeversityStatus(status);
+          setPrizeversityIdentifier(status.account?.email || currentUser?.email || '');
+          setSelectedRewardInstanceId(
+            status.account?.instanceId || status.instances?.[0]?.id || ''
+          );
+        }
+      })
+      .catch((err) => {
+        if (shouldUpdate) {
+          setError(getErrorMessage(err, 'Failed to load Prizeversity status'));
+        }
+      })
+      .finally(() => {
+        if (shouldUpdate) {
+          setIsPrizeversityLoading(false);
+        }
+      });
+
+    return () => {
+      shouldUpdate = false;
+    };
+  }, [isAuthenticated, currentUser?.email]);
 
   // Scroll to top when component mounts
   useEffect(() => {
@@ -438,6 +486,51 @@ function Account({ theme: _theme }: AccountProps) {
       setShowCyberModal(true);
     } else {
       setError('No AWS credentials found for your account');
+    }
+  };
+
+  const handlePrizeversityLink = async () => {
+    setIsPrizeversityLoading(true);
+    setError('');
+    setSuccess('');
+
+    try {
+      const response = await rewardIntegrationAPI.link(
+        prizeversityIdentifier,
+        selectedRewardInstanceId
+      );
+      setPrizeversityStatus(response.status);
+      setPrizeversityIdentifier(response.status.account?.email || prizeversityIdentifier);
+      setSelectedRewardInstanceId(
+        response.status.account?.instanceId || response.status.instances?.[0]?.id || ''
+      );
+      await refreshTokens();
+      setSuccess(response.message);
+      setTimeout(() => setSuccess(''), 4000);
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to link Prizeversity account'));
+    } finally {
+      setIsPrizeversityLoading(false);
+    }
+  };
+
+  const handlePrizeversityUnlink = async () => {
+    setIsPrizeversityLoading(true);
+    setError('');
+    setSuccess('');
+
+    try {
+      const response = await rewardIntegrationAPI.unlink();
+      setPrizeversityStatus(response.status);
+      setPrizeversityIdentifier(currentUser?.email || '');
+      setSelectedRewardInstanceId(response.status.instances?.[0]?.id || '');
+      await refreshTokens();
+      setSuccess(response.message);
+      setTimeout(() => setSuccess(''), 4000);
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to unlink Prizeversity account'));
+    } finally {
+      setIsPrizeversityLoading(false);
     }
   };
 
@@ -849,6 +942,148 @@ function Account({ theme: _theme }: AccountProps) {
                   </div>
                 </div>
               </div>
+            </div>
+          </motion.section>
+
+          <motion.section
+            className="prizeversity-section"
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.15 }}
+          >
+            <h2 className="account-challenge-heading">
+              <Link2 size={26} aria-hidden="true" /> Prizeversity Rewards
+            </h2>
+
+            <div className="prizeversity-card">
+              <div className="prizeversity-header">
+                <div className="prizeversity-icon">
+                  <Shield size={28} aria-hidden="true" />
+                </div>
+                <div className="prizeversity-title">
+                  <span>{prizeversityStatus?.linked ? 'Connected' : 'Account sync'}</span>
+                  <h3>Link your Prizeversity account</h3>
+                  <p>
+                    Challenge completions in AWS Student Hub will use this linked Prizeversity
+                    classroom account for rewards and progression.
+                  </p>
+                </div>
+              </div>
+
+              {!getStoredItem('accessToken') ? (
+                <div className="prizeversity-notice">
+                  Prizeversity linking requires an AWS Student Hub account session.
+                </div>
+              ) : prizeversityStatus && !prizeversityStatus.configured ? (
+                <div className="prizeversity-notice">
+                  Prizeversity integration is not configured yet. An admin needs to set the backend
+                  Prizeversity API URL, API key, and classroom ID.
+                </div>
+              ) : (
+                <>
+                  {prizeversityStatus?.linked && prizeversityStatus.account ? (
+                    <div className="prizeversity-linked-panel">
+                      <div className="prizeversity-linked-grid">
+                        <div>
+                          <span>Matched account</span>
+                          <strong>
+                            {prizeversityStatus.account.matchedName ||
+                              prizeversityStatus.account.email ||
+                              'Prizeversity user'}
+                          </strong>
+                        </div>
+                        <div>
+                          <span>Email</span>
+                          <strong>{prizeversityStatus.account.email || 'Not provided'}</strong>
+                        </div>
+                        <div>
+                          <span>Short ID</span>
+                          <strong>{prizeversityStatus.account.shortId || 'Not provided'}</strong>
+                        </div>
+                        <div>
+                          <span>Last synced</span>
+                          <strong>
+                            {prizeversityStatus.account.lastSyncedAt
+                              ? new Date(
+                                  prizeversityStatus.account.lastSyncedAt
+                                ).toLocaleDateString()
+                              : 'Just now'}
+                          </strong>
+                        </div>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="prizeversity-notice">
+                      Use the email, full name, or short ID from your Prizeversity classroom. If
+                      left blank, we will try your AWS Student Hub email first.
+                    </div>
+                  )}
+
+                  <div className="prizeversity-link-form">
+                    {prizeversityStatus?.instances && prizeversityStatus.instances.length > 1 && (
+                      <>
+                        <label htmlFor="prizeversity-instance">Reward classroom</label>
+                        <select
+                          id="prizeversity-instance"
+                          value={selectedRewardInstanceId}
+                          onChange={(event) => setSelectedRewardInstanceId(event.target.value)}
+                          disabled={isPrizeversityLoading}
+                          className="prizeversity-instance-select"
+                        >
+                          {prizeversityStatus.instances.map((instance) => (
+                            <option key={instance.id} value={instance.id}>
+                              {instance.name}
+                              {instance.classroomName ? ` - ${instance.classroomName}` : ''}
+                            </option>
+                          ))}
+                        </select>
+                      </>
+                    )}
+
+                    <label htmlFor="prizeversity-identifier">Prizeversity identifier</label>
+                    <div className="prizeversity-input-row">
+                      <input
+                        id="prizeversity-identifier"
+                        type="text"
+                        value={prizeversityIdentifier}
+                        onChange={(event) => setPrizeversityIdentifier(event.target.value)}
+                        placeholder={currentUser?.email || 'email@example.com'}
+                        disabled={isPrizeversityLoading}
+                      />
+                      <button
+                        type="button"
+                        className="show-modal-btn"
+                        onClick={handlePrizeversityLink}
+                        disabled={isPrizeversityLoading}
+                      >
+                        {isPrizeversityLoading ? (
+                          <>
+                            <RefreshCw size={16} aria-hidden="true" /> Syncing
+                          </>
+                        ) : (
+                          <>
+                            <RefreshCw size={16} aria-hidden="true" />
+                            {prizeversityStatus?.linked ? 'Re-sync' : 'Link account'}
+                          </>
+                        )}
+                      </button>
+                    </div>
+                  </div>
+
+                  {prizeversityStatus?.linked && (
+                    <div className="account-challenge-actions compact">
+                      <button
+                        type="button"
+                        className="hide-credentials-btn"
+                        onClick={handlePrizeversityUnlink}
+                        disabled={isPrizeversityLoading}
+                      >
+                        <Unlink size={16} aria-hidden="true" /> Unlink Prizeversity
+                      </button>
+                    </div>
+                  )}
+                </>
+              )}
             </div>
           </motion.section>
 

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -6,6 +6,10 @@ import { useToast } from '../context/ToastContext';
 import { adminAPI } from '../utils/api';
 import './styles/AdminDashboard.css';
 import type { AdminStats, AdminUser, EmailQueueEntry } from '../types/admin';
+import type {
+  RewardIntegrationInstance,
+  RewardIntegrationInstancePayload,
+} from '../types/rewardIntegration';
 import type { Theme } from '../types/ui';
 import type { UserRole, UserStatus } from '../types/user';
 
@@ -17,10 +21,20 @@ interface IconProps {
   className?: string;
 }
 
-type AdminTab = 'dashboard' | 'users' | 'queue';
+type AdminTab = 'dashboard' | 'users' | 'queue' | 'rewards';
 type RoleFilter = UserRole | '';
 type StatusFilter = UserStatus | '';
 type QueueStats = Record<string, any>;
+
+interface RewardIntegrationFormData {
+  name: string;
+  description: string;
+  apiBaseUrl: string;
+  apiKey: string;
+  classroomId: string;
+  classroomName: string;
+  scopes: string;
+}
 
 interface DashboardStats extends AdminStats {
   newsletterSubscribers?: number;
@@ -41,9 +55,25 @@ interface DashboardQueueEntry extends EmailQueueEntry {
 }
 
 const adminRoles: UserRole[] = ['moderator', 'admin', 'superuser'];
+const defaultRewardScopes = 'users:read,users:match,reward:grant';
+const emptyRewardForm: RewardIntegrationFormData = {
+  name: '',
+  description: '',
+  apiBaseUrl: 'https://www.prizeversity.com',
+  apiKey: '',
+  classroomId: '',
+  classroomName: '',
+  scopes: defaultRewardScopes,
+};
 
 const getErrorMessage = (err: unknown, fallback: string): string =>
   err instanceof Error ? err.message : fallback;
+
+const cleanPastedRewardValue = (value: string): string =>
+  value
+    .trim()
+    .replace(/^["'`]+|["'`]+$/g, '')
+    .trim();
 
 const getUserId = (targetUser?: AdminUser | null): string =>
   String(targetUser?._id || targetUser?.id || '');
@@ -140,6 +170,13 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
   const [processingQueue, setProcessingQueue] = useState<boolean>(false);
   const [retryingId, setRetryingId] = useState<string | null>(null);
 
+  // Reward integration state
+  const [rewardInstances, setRewardInstances] = useState<RewardIntegrationInstance[]>([]);
+  const [rewardForm, setRewardForm] = useState<RewardIntegrationFormData>(emptyRewardForm);
+  const [rewardLoading, setRewardLoading] = useState<boolean>(false);
+  const [rewardSaving, setRewardSaving] = useState<boolean>(false);
+  const [testingRewardId, setTestingRewardId] = useState<string | null>(null);
+
   const navigate = useNavigate();
   const { user, loading: authLoading } = useAuth();
   const { showToast } = useToast();
@@ -173,18 +210,20 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
       );
       setUsers(response.users as AdminUser[]);
       setTotalPages(response.pagination?.totalPages || 1);
-    } catch {
-      showToast('Failed to load users', 'error');
+      setError('');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to load users'));
     } finally {
       setUsersLoading(false);
     }
-  }, [currentPage, searchTerm, roleFilter, statusFilter, showToast]);
+  }, [currentPage, searchTerm, roleFilter, statusFilter]);
 
   useEffect(() => {
     const loadStats = async () => {
       try {
         const response = await adminAPI.getDashboardStats();
         setStats(response.stats as DashboardStats);
+        setError('');
       } catch {
         setError('Failed to load dashboard stats');
       } finally {
@@ -209,7 +248,7 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
       const response = await adminAPI.getEmailQueueStats();
       setQueueStats(response.stats);
     } catch (err) {
-      console.error('failed to load queue stats.', err);
+      setError(getErrorMessage(err, 'Failed to load queue stats'));
     }
   }, []);
 
@@ -223,12 +262,13 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
       );
       setQueueEntries((response.entries || []) as DashboardQueueEntry[]);
       setQueueTotalPages(response.pagination?.totalPages || 1);
-    } catch {
-      showToast('Failed to load queue entries', 'error');
+      setError('');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to load queue entries'));
     } finally {
       setQueueLoading(false);
     }
-  }, [queueStatusFilter, queuePage, showToast]);
+  }, [queueStatusFilter, queuePage]);
 
   useEffect(() => {
     if (activeTab === 'queue') {
@@ -236,6 +276,25 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
       loadQueueEntries();
     }
   }, [activeTab, loadQueueStats, loadQueueEntries]);
+
+  const loadRewardIntegrations = useCallback(async () => {
+    setRewardLoading(true);
+    try {
+      const response = await adminAPI.listRewardIntegrations();
+      setRewardInstances(response.instances || []);
+      setError('');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to load reward integrations'));
+    } finally {
+      setRewardLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (activeTab === 'rewards') {
+      loadRewardIntegrations();
+    }
+  }, [activeTab, loadRewardIntegrations]);
 
   const handleRetryEmail = async (queueId: string) => {
     if (!queueId) {
@@ -271,6 +330,73 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
       showToast(getErrorMessage(err, 'Failed to process queue'), 'error');
     } finally {
       setProcessingQueue(false);
+    }
+  };
+
+  const handleRewardFieldChange = (field: keyof RewardIntegrationFormData, value: string) => {
+    setRewardForm((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const buildRewardPayload = (): RewardIntegrationInstancePayload => ({
+    name: cleanPastedRewardValue(rewardForm.name),
+    description: cleanPastedRewardValue(rewardForm.description),
+    apiBaseUrl: cleanPastedRewardValue(rewardForm.apiBaseUrl),
+    apiKey: cleanPastedRewardValue(rewardForm.apiKey),
+    classroomId: cleanPastedRewardValue(rewardForm.classroomId),
+    classroomName: cleanPastedRewardValue(rewardForm.classroomName),
+    scopes: rewardForm.scopes.split(',').map(cleanPastedRewardValue).filter(Boolean),
+    active: true,
+  });
+
+  const handleCreateRewardIntegration = async () => {
+    const payload = buildRewardPayload();
+    if (!payload.name || !payload.apiKey || !payload.classroomId) {
+      showToast('Name, API key, and classroom ID are required', 'error');
+      return;
+    }
+
+    setRewardSaving(true);
+    try {
+      await adminAPI.createRewardIntegration(payload);
+      showToast('Reward integration instance created', 'success');
+      setRewardForm(emptyRewardForm);
+      loadRewardIntegrations();
+    } catch (err) {
+      showToast(getErrorMessage(err, 'Failed to create reward integration'), 'error');
+    } finally {
+      setRewardSaving(false);
+    }
+  };
+
+  const handleTestRewardIntegration = async (instanceId: string) => {
+    setTestingRewardId(instanceId);
+    try {
+      const response = await adminAPI.testRewardIntegration(instanceId);
+      showToast(`Verified ${response.test?.userCount ?? 0} classroom users`, 'success');
+      loadRewardIntegrations();
+    } catch (err) {
+      showToast(getErrorMessage(err, 'Failed to verify reward integration'), 'error');
+      loadRewardIntegrations();
+    } finally {
+      setTestingRewardId(null);
+    }
+  };
+
+  const handleToggleRewardIntegration = async (instance: RewardIntegrationInstance) => {
+    try {
+      if (instance.active) {
+        await adminAPI.deactivateRewardIntegration(instance.id);
+        showToast('Reward integration deactivated', 'success');
+      } else {
+        await adminAPI.updateRewardIntegration(instance.id, { active: true });
+        showToast('Reward integration activated', 'success');
+      }
+      loadRewardIntegrations();
+    } catch (err) {
+      showToast(getErrorMessage(err, 'Failed to update reward integration'), 'error');
     }
   };
 
@@ -381,6 +507,16 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
             <AccountIcon className="tab-icon" />
             User Management
           </button>
+          {(user?.role === 'admin' || user?.role === 'superuser') && (
+            <button
+              className={`tab-button ${activeTab === 'rewards' ? 'active' : ''}`}
+              data-tab="rewards"
+              onClick={() => setActiveTab('rewards')}
+            >
+              <AwsIcon className="tab-icon" />
+              Reward Integrations
+            </button>
+          )}
           {(user?.role === 'admin' || user?.role === 'superuser') && (
             <button
               className={`tab-button ${activeTab === 'queue' ? 'active' : ''}`}
@@ -631,6 +767,184 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
                 )}
               </>
             )}
+          </motion.div>
+        )}
+
+        {activeTab === 'rewards' && (
+          <motion.div
+            className="rewards-content"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            <div className="reward-admin-grid">
+              <section className="reward-admin-panel">
+                <div className="reward-admin-heading">
+                  <span>New instance</span>
+                  <h2>Prizeversity classroom</h2>
+                  <p>
+                    Store a Prizeversity integration API key scoped to one classroom. AWS Student
+                    Hub uses this server-side key for account linking and challenge rewards.
+                  </p>
+                </div>
+
+                <div className="reward-form">
+                  <label>
+                    Instance name
+                    <input
+                      type="text"
+                      value={rewardForm.name}
+                      onChange={(e) => handleRewardFieldChange('name', e.target.value)}
+                      placeholder="Cyber Challenge Section A"
+                    />
+                  </label>
+
+                  <label>
+                    Classroom ID
+                    <input
+                      type="text"
+                      value={rewardForm.classroomId}
+                      onChange={(e) => handleRewardFieldChange('classroomId', e.target.value)}
+                      placeholder="68e169fa349b208d3db7b129"
+                    />
+                  </label>
+
+                  <label>
+                    API key
+                    <input
+                      type="password"
+                      value={rewardForm.apiKey}
+                      onChange={(e) => handleRewardFieldChange('apiKey', e.target.value)}
+                      placeholder="pvk_..."
+                    />
+                  </label>
+
+                  <label>
+                    Prizeversity base URL
+                    <input
+                      type="url"
+                      value={rewardForm.apiBaseUrl}
+                      onChange={(e) => handleRewardFieldChange('apiBaseUrl', e.target.value)}
+                      placeholder="https://prizeversity.com"
+                    />
+                  </label>
+
+                  <label>
+                    Classroom label
+                    <input
+                      type="text"
+                      value={rewardForm.classroomName}
+                      onChange={(e) => handleRewardFieldChange('classroomName', e.target.value)}
+                      placeholder="Optional; verified value will replace this when available"
+                    />
+                  </label>
+
+                  <label>
+                    Expected scopes
+                    <input
+                      type="text"
+                      value={rewardForm.scopes}
+                      onChange={(e) => handleRewardFieldChange('scopes', e.target.value)}
+                    />
+                  </label>
+
+                  <label>
+                    Description
+                    <textarea
+                      value={rewardForm.description}
+                      onChange={(e) => handleRewardFieldChange('description', e.target.value)}
+                      placeholder="Who should use this classroom integration?"
+                    />
+                  </label>
+
+                  <button
+                    type="button"
+                    className="create-reward-instance-btn"
+                    onClick={handleCreateRewardIntegration}
+                    disabled={rewardSaving}
+                  >
+                    {rewardSaving ? 'Verifying...' : 'Create and verify instance'}
+                  </button>
+                </div>
+              </section>
+
+              <section className="reward-admin-panel">
+                <div className="reward-admin-heading">
+                  <span>Configured</span>
+                  <h2>Reward instances</h2>
+                  <p>
+                    Active instances appear on user account linking. API keys are never returned to
+                    the browser after creation.
+                  </p>
+                </div>
+
+                {rewardLoading ? (
+                  <div className="loading-users">Loading reward integrations...</div>
+                ) : rewardInstances.length === 0 ? (
+                  <div className="empty-reward-instances">
+                    No reward integration instances have been created yet.
+                  </div>
+                ) : (
+                  <div className="reward-instance-list">
+                    {rewardInstances.map((instance) => (
+                      <article key={instance.id} className="reward-instance-card">
+                        <div className="reward-instance-topline">
+                          <span data-active={instance.active}>
+                            {instance.active ? 'Active' : 'Inactive'}
+                          </span>
+                          <span>{instance.lastVerificationStatus || 'untested'}</span>
+                        </div>
+                        <h3>{instance.name}</h3>
+                        <p>{instance.description || 'No description provided.'}</p>
+
+                        <div className="reward-instance-meta">
+                          <div>
+                            <span>Classroom</span>
+                            <strong>{instance.classroomName || instance.classroomId}</strong>
+                          </div>
+                          <div>
+                            <span>Classroom ID</span>
+                            <strong>{instance.classroomId}</strong>
+                          </div>
+                          <div>
+                            <span>API key</span>
+                            <strong>{instance.apiKeyPreview || 'Stored'}</strong>
+                          </div>
+                          <div>
+                            <span>Users seen</span>
+                            <strong>{instance.lastUserCount ?? 'Not tested'}</strong>
+                          </div>
+                        </div>
+
+                        {instance.lastVerificationError && (
+                          <div className="reward-instance-error">
+                            {instance.lastVerificationError}
+                          </div>
+                        )}
+
+                        <div className="reward-instance-actions">
+                          <button
+                            type="button"
+                            className="action-btn role-btn"
+                            onClick={() => handleTestRewardIntegration(instance.id)}
+                            disabled={testingRewardId === instance.id}
+                          >
+                            {testingRewardId === instance.id ? 'Testing...' : 'Test'}
+                          </button>
+                          <button
+                            type="button"
+                            className={`action-btn ${instance.active ? 'ban-btn' : 'unban-btn'}`}
+                            onClick={() => handleToggleRewardIntegration(instance)}
+                          >
+                            {instance.active ? 'Deactivate' : 'Activate'}
+                          </button>
+                        </div>
+                      </article>
+                    ))}
+                  </div>
+                )}
+              </section>
+            </div>
           </motion.div>
         )}
 

--- a/frontend/src/pages/Auth.tsx
+++ b/frontend/src/pages/Auth.tsx
@@ -246,7 +246,7 @@ function Auth({ theme }: AuthProps) {
         return;
       }
 
-      if (currentUser && !currentUser.profileSetupCompleted) {
+      if (currentUser && currentUser.profileSetupCompleted === false) {
         navigate('/setup', { replace: true });
       } else {
         navigate(redirectPath, { replace: true });

--- a/frontend/src/pages/Challenges.tsx
+++ b/frontend/src/pages/Challenges.tsx
@@ -2,8 +2,10 @@ import { useState, useEffect } from 'react';
 import { motion } from 'motion/react';
 import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
-import { Target, Star, Trophy } from 'lucide-react';
+import { Link2, ShieldCheck, Target, Star, Trophy, X } from 'lucide-react';
+import { rewardIntegrationAPI } from '../utils/api';
 import type { ThemeProps } from '../types';
+import type { RewardIntegrationStatusResponse } from '../types/rewardIntegration';
 import './styles/Challenges.css';
 import '../pages/styles/Landing.css';
 
@@ -29,6 +31,13 @@ function Challenges({ theme: _theme }: ThemeProps) {
   const [activeTab, setActiveTab] = useState<ChallengeTab>('all');
   const [challenges] = useState<Challenge[]>([]);
   const [loading, setLoading] = useState(true);
+  const [rewardStatus, setRewardStatus] = useState<RewardIntegrationStatusResponse | null>(null);
+  const [rewardStatusLoading, setRewardStatusLoading] = useState<boolean>(false);
+  const [rewardStatusError, setRewardStatusError] = useState<string>('');
+  const [rewardGateDismissed, setRewardGateDismissed] = useState<boolean>(false);
+  const rewardGateDismissKey = user
+    ? `awsStudentHub:challengeRewardGateDismissed:${user.id || user._id || user.email}`
+    : '';
 
   useEffect(() => {
     const loadChallenges = async () => {
@@ -37,8 +46,64 @@ function Challenges({ theme: _theme }: ThemeProps) {
     loadChallenges();
   }, []);
 
+  useEffect(() => {
+    if (!user) {
+      setRewardStatus(null);
+      setRewardStatusError('');
+      return;
+    }
+
+    let shouldUpdate = true;
+    setRewardStatusLoading(true);
+    setRewardStatusError('');
+
+    rewardIntegrationAPI
+      .status()
+      .then((status) => {
+        if (shouldUpdate) {
+          setRewardStatus(status);
+        }
+      })
+      .catch((err) => {
+        if (shouldUpdate) {
+          setRewardStatusError(
+            err instanceof Error ? err.message : 'Failed to load Prizeversity link status'
+          );
+        }
+      })
+      .finally(() => {
+        if (shouldUpdate) {
+          setRewardStatusLoading(false);
+        }
+      });
+
+    return () => {
+      shouldUpdate = false;
+    };
+  }, [user]);
+
+  useEffect(() => {
+    if (!rewardGateDismissKey) {
+      setRewardGateDismissed(false);
+      return;
+    }
+
+    setRewardGateDismissed(localStorage.getItem(rewardGateDismissKey) === 'true');
+  }, [rewardGateDismissKey]);
+
   const handleSignIn = () => {
     navigate('/auth?redirect=/challenges');
+  };
+
+  const handleLinkPrizeversity = () => {
+    navigate('/account#prizeversity-rewards');
+  };
+
+  const handleDismissRewardGate = () => {
+    if (rewardGateDismissKey) {
+      localStorage.setItem(rewardGateDismissKey, 'true');
+    }
+    setRewardGateDismissed(true);
   };
 
   const filteredChallenges = challenges.filter((c) => {
@@ -99,6 +164,58 @@ function Challenges({ theme: _theme }: ThemeProps) {
           >
             <p>Sign in to track your progress and earn points</p>
             <button onClick={handleSignIn}>Sign In</button>
+          </motion.div>
+        )}
+
+        {user && (!rewardStatus?.linked || !rewardGateDismissed) && (
+          <motion.div
+            className={`challenges-reward-gate ${rewardStatus?.linked ? 'linked' : ''}`}
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.28 }}
+          >
+            <div className="reward-gate-icon" aria-hidden="true">
+              {rewardStatus?.linked ? <ShieldCheck size={26} /> : <Link2 size={26} />}
+            </div>
+            <div className="reward-gate-copy">
+              <span>{rewardStatus?.linked ? 'Rewards connected' : 'Required before play'}</span>
+              <h3>
+                {rewardStatus?.linked
+                  ? 'Prizeversity is linked for challenge rewards.'
+                  : 'Link Prizeversity to unlock rewardable challenges.'}
+              </h3>
+              <p>
+                {rewardStatusLoading
+                  ? 'Checking your classroom reward link...'
+                  : rewardStatusError
+                    ? rewardStatusError
+                    : rewardStatus?.linked
+                      ? `Completions will sync to ${rewardStatus.account?.matchedName || rewardStatus.account?.email || 'your Prizeversity classroom account'}.`
+                      : rewardStatus && !rewardStatus.configured
+                        ? 'An admin needs to configure a Prizeversity classroom instance before challenges can award progress.'
+                        : 'Use your AWS Student Hub profile to connect the Prizeversity classroom account that will receive challenge progress and rewards.'}
+              </p>
+            </div>
+            {!rewardStatus?.linked && (
+              <button
+                type="button"
+                className="reward-gate-button"
+                onClick={handleLinkPrizeversity}
+                disabled={rewardStatusLoading || Boolean(rewardStatus && !rewardStatus.configured)}
+              >
+                Link in Account
+              </button>
+            )}
+            {rewardStatus?.linked && (
+              <button
+                type="button"
+                className="reward-gate-dismiss"
+                onClick={handleDismissRewardGate}
+                aria-label="Dismiss rewards connected message"
+              >
+                <X size={18} strokeWidth={2.5} aria-hidden="true" />
+              </button>
+            )}
           </motion.div>
         )}
 

--- a/frontend/src/pages/styles/Account.css
+++ b/frontend/src/pages/styles/Account.css
@@ -1007,6 +1007,7 @@
 }
 
 .prizeversity-input-row input,
+.prizeversity-code-row input,
 .prizeversity-instance-select {
   width: 100%;
   border: 1px solid rgba(var(--text-primary-rgb), 0.1);
@@ -1022,6 +1023,7 @@
 }
 
 .prizeversity-input-row input:focus,
+.prizeversity-code-row input:focus,
 .prizeversity-instance-select:focus {
   border-color: rgba(var(--accent-rgb), 0.45);
   outline: none;
@@ -1029,11 +1031,72 @@
 }
 
 .prizeversity-input-row input:disabled,
+.prizeversity-code-row input:disabled,
 .prizeversity-instance-select:disabled,
 .prizeversity-input-row button:disabled,
+.prizeversity-code-row button:disabled,
 .account-challenge-actions button:disabled {
   cursor: not-allowed;
   opacity: 0.65;
+}
+
+.prizeversity-verification-panel {
+  display: grid;
+  gap: 0.85rem;
+  margin-top: 1rem;
+  color: var(--text-primary);
+  background: rgba(var(--accent-rgb), 0.08);
+  border: 1px solid rgba(var(--accent-rgb), 0.2);
+  border-radius: 18px;
+  padding: 1rem 1.15rem;
+  line-height: 1.5;
+}
+
+.prizeversity-verification-panel strong {
+  display: block;
+  margin-bottom: 0.2rem;
+}
+
+.prizeversity-verification-panel span {
+  color: var(--text-secondary);
+}
+
+.prizeversity-code-row {
+  display: grid;
+  grid-template-columns: minmax(0, 11rem) auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.prizeversity-code-row input {
+  letter-spacing: 0.18em;
+  text-align: center;
+}
+
+.prizeversity-link-error {
+  display: grid;
+  gap: 0.35rem;
+  margin-top: 1rem;
+  color: #991b1b;
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.22);
+  border-radius: 18px;
+  padding: 1.15rem 1.25rem;
+  line-height: 1.5;
+}
+
+.prizeversity-link-error strong {
+  color: #7f1d1d;
+  font-size: 0.92rem;
+}
+
+.prizeversity-link-error span,
+.prizeversity-link-error small {
+  color: inherit;
+}
+
+.prizeversity-link-error small {
+  opacity: 0.86;
 }
 
 .account-challenge-heading {
@@ -1142,6 +1205,42 @@
 
 .account-credentials-section {
   margin-top: 1rem;
+}
+
+.account-challenge-gate {
+  margin-top: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(var(--accent-rgb), 0.28);
+  border-radius: 18px;
+  background:
+    linear-gradient(135deg, rgba(var(--accent-rgb), 0.13), transparent 55%),
+    rgba(var(--text-primary-rgb), 0.025);
+}
+
+.account-challenge-gate span {
+  display: inline-flex;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 0.35rem;
+}
+
+.account-challenge-gate h4 {
+  color: var(--text-primary);
+  font-size: 1rem;
+  margin: 0 0 0.35rem;
+}
+
+.account-challenge-gate p {
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin: 0;
 }
 
 .account-challenge-actions {
@@ -1369,11 +1468,13 @@
   }
 
   .prizeversity-linked-grid,
-  .prizeversity-input-row {
+  .prizeversity-input-row,
+  .prizeversity-code-row {
     grid-template-columns: 1fr;
   }
 
-  .prizeversity-input-row button {
+  .prizeversity-input-row button,
+  .prizeversity-code-row button {
     width: 100%;
   }
 
@@ -1383,6 +1484,11 @@
 
   .account-challenge-meta-grid {
     grid-template-columns: 1fr;
+  }
+
+  .account-challenge-gate {
+    align-items: stretch;
+    flex-direction: column;
   }
 
   .account-credential-row {

--- a/frontend/src/pages/styles/Account.css
+++ b/frontend/src/pages/styles/Account.css
@@ -880,7 +880,8 @@
   }
 }
 
-/* Cyber Challenge Section */
+/* Reward integration and challenge sections */
+.prizeversity-section,
 .cyber-challenge-section {
   --challenge-panel: rgba(var(--text-primary-rgb), 0.025);
   --challenge-panel-strong: rgba(var(--text-primary-rgb), 0.045);
@@ -896,6 +897,143 @@
   color: var(--text-primary);
   text-align: left;
   font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+}
+
+.prizeversity-card {
+  background: var(--challenge-panel);
+  border: 1px solid var(--challenge-border);
+  border-radius: 22px;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.prizeversity-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.prizeversity-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: rgba(var(--accent-secondary-rgb), 0.12);
+  color: var(--accent-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(var(--accent-secondary-rgb), 0.18);
+  flex-shrink: 0;
+}
+
+.prizeversity-title span {
+  display: block;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 0.25rem;
+}
+
+.prizeversity-title h3 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: clamp(1.15rem, 2vw, 1.45rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.prizeversity-title p {
+  margin: 0.35rem 0 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.prizeversity-notice {
+  color: var(--text-secondary);
+  background: rgba(var(--text-primary-rgb), 0.035);
+  border: 1px solid rgba(var(--text-primary-rgb), 0.08);
+  border-radius: 14px;
+  padding: 1rem;
+  line-height: 1.55;
+}
+
+.prizeversity-linked-panel {
+  background: rgba(var(--accent-rgb), 0.07);
+  border: 1px solid rgba(var(--accent-rgb), 0.16);
+  border-radius: 18px;
+  padding: 1rem;
+}
+
+.prizeversity-linked-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.prizeversity-linked-grid div {
+  min-width: 0;
+}
+
+.prizeversity-linked-grid span,
+.prizeversity-link-form label {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 0.4rem;
+}
+
+.prizeversity-linked-grid strong {
+  display: block;
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  word-break: break-word;
+}
+
+.prizeversity-link-form {
+  margin-top: 1rem;
+}
+
+.prizeversity-input-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.prizeversity-input-row input,
+.prizeversity-instance-select {
+  width: 100%;
+  border: 1px solid rgba(var(--text-primary-rgb), 0.1);
+  border-radius: 999px;
+  background: rgba(var(--text-primary-rgb), 0.045);
+  color: var(--text-primary);
+  font: inherit;
+  padding: 0.78rem 1rem;
+}
+
+.prizeversity-instance-select {
+  margin-bottom: 0.9rem;
+}
+
+.prizeversity-input-row input:focus,
+.prizeversity-instance-select:focus {
+  border-color: rgba(var(--accent-rgb), 0.45);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.1);
+}
+
+.prizeversity-input-row input:disabled,
+.prizeversity-instance-select:disabled,
+.prizeversity-input-row button:disabled,
+.account-challenge-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }
 
 .account-challenge-heading {
@@ -1221,8 +1359,22 @@
 }
 
 @media (max-width: 768px) {
+  .prizeversity-section,
   .cyber-challenge-section {
     padding: 1.25rem;
+  }
+
+  .prizeversity-header {
+    align-items: flex-start;
+  }
+
+  .prizeversity-linked-grid,
+  .prizeversity-input-row {
+    grid-template-columns: 1fr;
+  }
+
+  .prizeversity-input-row button {
+    width: 100%;
   }
 
   .account-challenge-header {

--- a/frontend/src/pages/styles/AdminDashboard.css
+++ b/frontend/src/pages/styles/AdminDashboard.css
@@ -96,6 +96,7 @@
 
 .dashboard-content,
 .users-content,
+.rewards-content,
 .queue-content {
   animation: fadeInUp 0.5s ease forwards;
 }
@@ -223,6 +224,194 @@
   overflow: hidden;
   margin-bottom: 30px;
   box-shadow: 0 4px 12px var(--card-shadow);
+}
+
+.reward-admin-grid {
+  display: grid;
+  grid-template-columns: minmax(320px, 0.9fr) minmax(0, 1.1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.reward-admin-panel {
+  background-color: var(--bg-secondary);
+  border: 1px solid rgba(var(--text-secondary-rgb), 0.1);
+  border-radius: 18px;
+  padding: 24px;
+  box-shadow: 0 4px 12px var(--card-shadow);
+  text-align: left;
+}
+
+.reward-admin-heading {
+  margin-bottom: 20px;
+}
+
+.reward-admin-heading span,
+.reward-instance-topline span {
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.reward-admin-heading h2 {
+  color: var(--text-primary);
+  font-size: 1.45rem;
+  margin: 6px 0 8px;
+}
+
+.reward-admin-heading p,
+.reward-instance-card p {
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin: 0;
+}
+
+.reward-form {
+  display: grid;
+  gap: 14px;
+}
+
+.reward-form label {
+  color: var(--text-primary);
+  display: grid;
+  gap: 7px;
+  font-weight: 700;
+}
+
+.reward-form input,
+.reward-form textarea {
+  width: 100%;
+  background: var(--bg-primary);
+  border: 2px solid rgba(var(--text-secondary-rgb), 0.18);
+  border-radius: 12px;
+  color: var(--text-primary);
+  font: inherit;
+  padding: 12px 14px;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.reward-form textarea {
+  min-height: 90px;
+  resize: vertical;
+}
+
+.reward-form input:focus,
+.reward-form textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.1);
+  outline: none;
+}
+
+.create-reward-instance-btn {
+  background: linear-gradient(135deg, var(--accent), var(--accent-secondary));
+  border: none;
+  border-radius: 999px;
+  color: #111827;
+  cursor: pointer;
+  font-weight: 800;
+  padding: 13px 18px;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+
+.create-reward-instance-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.create-reward-instance-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.empty-reward-instances {
+  background: rgba(var(--text-secondary-rgb), 0.06);
+  border: 1px dashed rgba(var(--text-secondary-rgb), 0.22);
+  border-radius: 14px;
+  color: var(--text-secondary);
+  padding: 24px;
+  text-align: center;
+}
+
+.reward-instance-list {
+  display: grid;
+  gap: 16px;
+}
+
+.reward-instance-card {
+  background: var(--bg-primary);
+  border: 1px solid rgba(var(--text-secondary-rgb), 0.12);
+  border-radius: 16px;
+  padding: 18px;
+}
+
+.reward-instance-topline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.reward-instance-topline span[data-active='false'] {
+  color: var(--text-secondary);
+}
+
+.reward-instance-card h3 {
+  color: var(--text-primary);
+  font-size: 1.18rem;
+  margin: 0 0 8px;
+}
+
+.reward-instance-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 16px 0;
+}
+
+.reward-instance-meta div {
+  min-width: 0;
+  background: rgba(var(--text-secondary-rgb), 0.06);
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.reward-instance-meta span {
+  color: var(--text-secondary);
+  display: block;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  margin-bottom: 5px;
+  text-transform: uppercase;
+}
+
+.reward-instance-meta strong {
+  color: var(--text-primary);
+  display: block;
+  font-size: 0.9rem;
+  word-break: break-word;
+}
+
+.reward-instance-error {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 12px;
+  color: #ef4444;
+  font-weight: 700;
+  margin-bottom: 14px;
+  padding: 10px 12px;
+}
+
+.reward-instance-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
 .table-header {
@@ -972,6 +1161,10 @@
 
 /* Queue responsive */
 @media (max-width: 992px) {
+  .reward-admin-grid {
+    grid-template-columns: 1fr;
+  }
+
   .queue-stats-grid {
     grid-template-columns: repeat(2, 1fr);
   }
@@ -1004,6 +1197,18 @@
 }
 
 @media (max-width: 576px) {
+  .reward-instance-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .reward-instance-actions {
+    flex-direction: column;
+  }
+
+  .reward-instance-actions .action-btn {
+    width: 100%;
+  }
+
   .queue-stats-grid {
     grid-template-columns: 1fr 1fr;
     gap: 12px;

--- a/frontend/src/pages/styles/Challenges.css
+++ b/frontend/src/pages/styles/Challenges.css
@@ -82,6 +82,126 @@
   margin: 0 auto;
 }
 
+.challenges-reward-gate {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 1.1rem;
+  background:
+    linear-gradient(135deg, rgba(255, 153, 0, 0.14), rgba(35, 47, 62, 0.08)), var(--card-bg);
+  border: 1px solid rgba(255, 153, 0, 0.34);
+  border-radius: 18px;
+  padding: 1.25rem 1.4rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+}
+
+.challenges-reward-gate.linked {
+  background:
+    linear-gradient(135deg, rgba(34, 197, 94, 0.13), rgba(255, 153, 0, 0.07)), var(--card-bg);
+  border-color: rgba(34, 197, 94, 0.28);
+}
+
+.reward-gate-icon {
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  background: rgba(255, 153, 0, 0.16);
+  color: var(--accent-color);
+}
+
+.challenges-reward-gate.linked .reward-gate-icon {
+  background: rgba(34, 197, 94, 0.14);
+  color: #16a34a;
+}
+
+.reward-gate-copy {
+  flex: 1;
+}
+
+.reward-gate-copy span {
+  color: var(--accent-color);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.challenges-reward-gate.linked .reward-gate-copy span {
+  color: #16a34a;
+}
+
+.reward-gate-copy h3 {
+  color: var(--text-primary);
+  margin: 0.25rem 0 0.35rem;
+  font-size: 1.15rem;
+}
+
+.reward-gate-copy p {
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin: 0;
+}
+
+.reward-gate-button {
+  border: none;
+  border-radius: 999px;
+  background: var(--accent-color);
+  color: white;
+  cursor: pointer;
+  font-weight: 800;
+  padding: 0.75rem 1rem;
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s,
+    opacity 0.2s;
+}
+
+.reward-gate-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(255, 153, 0, 0.2);
+}
+
+.reward-gate-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.56;
+}
+
+.reward-gate-dismiss {
+  position: absolute;
+  top: 0.9rem;
+  right: 0.9rem;
+  width: 2.1rem;
+  height: 2.1rem;
+  padding: 0;
+  border: 1px solid rgba(22, 101, 52, 0.18);
+  border-radius: 999px;
+  background: rgba(22, 163, 74, 0.1);
+  color: #14532d;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background 0.2s,
+    transform 0.2s;
+}
+
+.reward-gate-dismiss svg {
+  display: block;
+  flex: 0 0 auto;
+  stroke: currentColor;
+}
+
+.reward-gate-dismiss:hover {
+  background: rgba(22, 163, 74, 0.18);
+  transform: translateY(-1px);
+}
+
 .challenges-tabs {
   display: flex;
   gap: 0.5rem;
@@ -274,6 +394,13 @@
 
   .challenges-coming-soon {
     padding: 1.5rem;
+  }
+
+  .challenges-reward-gate {
+    align-items: stretch;
+    flex-direction: column;
+    padding-right: 3.6rem;
+    text-align: left;
   }
 
   .challenges-tabs {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2,5 +2,6 @@ export type * from './admin';
 export type * from './api';
 export type * from './auth';
 export type * from './event';
+export type * from './rewardIntegration';
 export type * from './ui';
 export type * from './user';

--- a/frontend/src/types/rewardIntegration.ts
+++ b/frontend/src/types/rewardIntegration.ts
@@ -1,0 +1,57 @@
+import type { User } from './user';
+
+export interface LinkedRewardAccount {
+  instanceId?: string;
+  userId: string;
+  classroomId: string;
+  email?: string;
+  matchedName?: string;
+  shortId?: string;
+  linkedAt?: string;
+  lastSyncedAt?: string;
+}
+
+export interface RewardIntegrationInstance {
+  id: string;
+  source: 'database' | 'environment';
+  provider: 'prizeversity';
+  name: string;
+  description?: string;
+  apiBaseUrl: string;
+  apiKeyPreview?: string;
+  classroomId: string;
+  classroomName?: string;
+  scopes: string[];
+  active: boolean;
+  lastVerifiedAt?: string | null;
+  lastVerificationStatus?: string;
+  lastVerificationError?: string;
+  lastUserCount?: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface RewardIntegrationStatusResponse {
+  configured: boolean;
+  linked: boolean;
+  missingConfig: string[];
+  account: LinkedRewardAccount | null;
+  instances: RewardIntegrationInstance[];
+}
+
+export interface RewardIntegrationLinkResponse {
+  message: string;
+  status: RewardIntegrationStatusResponse;
+  user: User;
+}
+
+export interface RewardIntegrationInstancePayload {
+  name: string;
+  description?: string;
+  apiBaseUrl: string;
+  apiKey?: string;
+  classroomId: string;
+  classroomName?: string;
+  scopes?: string[];
+  active?: boolean;
+}

--- a/frontend/src/types/rewardIntegration.ts
+++ b/frontend/src/types/rewardIntegration.ts
@@ -43,6 +43,9 @@ export interface RewardIntegrationLinkResponse {
   message: string;
   status: RewardIntegrationStatusResponse;
   user: User;
+  verificationRequired?: boolean;
+  maskedEmail?: string;
+  expiresAt?: string;
 }
 
 export interface RewardIntegrationInstancePayload {

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -23,6 +23,13 @@ export interface User {
   awsAccessKeyId?: string;
   awsSecretAccessKey?: string;
   hasViewedAwsCredentials?: boolean;
+  prizeversityUserId?: string;
+  prizeversityClassroomId?: string;
+  prizeversityEmail?: string;
+  prizeversityMatchedName?: string;
+  prizeversityShortId?: string;
+  prizeversityLinkedAt?: string | null;
+  prizeversityLastSyncedAt?: string | null;
 }
 
 export interface PublicProfile {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -2,6 +2,12 @@ import type { AdminStats, EmailQueueEntry } from '../types/admin';
 import type { ApiResponse } from '../types/api';
 import type { AuthResponse, LoginCredentials, SignupPayload } from '../types/auth';
 import type { Event as FrontendEvent, EventFormPayload } from '../types/event';
+import type {
+  RewardIntegrationInstance,
+  RewardIntegrationInstancePayload,
+  RewardIntegrationLinkResponse,
+  RewardIntegrationStatusResponse,
+} from '../types/rewardIntegration';
 import type { PublicProfile, User, UserRole } from '../types/user';
 
 const API_BASE_URL =
@@ -443,6 +449,43 @@ export const discordAPI = {
   },
 };
 
+export const rewardIntegrationAPI = {
+  status: async (): Promise<RewardIntegrationStatusResponse> => {
+    return apiRequest('/integrations/prizeversity/status');
+  },
+
+  link: async (
+    identifier?: string,
+    instanceId?: string
+  ): Promise<RewardIntegrationLinkResponse> => {
+    return apiRequest('/integrations/prizeversity/link', {
+      method: 'POST',
+      body: JSON.stringify({ identifier, instanceId }),
+    });
+  },
+
+  unlink: async (): Promise<RewardIntegrationLinkResponse> => {
+    return apiRequest('/integrations/prizeversity/link', {
+      method: 'DELETE',
+    });
+  },
+};
+
+interface RewardIntegrationInstancesResponse {
+  instances: RewardIntegrationInstance[];
+}
+
+interface RewardIntegrationInstanceResponse {
+  message?: string;
+  instance: RewardIntegrationInstance;
+  test?: {
+    classroomId: string;
+    classroomName?: string;
+    userCount: number;
+    verifiedAt: string;
+  };
+}
+
 export const adminAPI = {
   getDashboardStats: async (): Promise<{ stats: AdminStats; [key: string]: any }> => {
     const response = await fetch(`${API_BASE_URL}/admin/dashboard/stats`, {
@@ -621,6 +664,43 @@ export const adminAPI = {
     }
 
     return response.json() as Promise<ProcessEmailQueueResponse>;
+  },
+
+  listRewardIntegrations: async (): Promise<RewardIntegrationInstancesResponse> => {
+    return apiRequest('/admin/reward-integrations');
+  },
+
+  createRewardIntegration: async (
+    payload: RewardIntegrationInstancePayload
+  ): Promise<RewardIntegrationInstanceResponse> => {
+    return apiRequest('/admin/reward-integrations', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  },
+
+  updateRewardIntegration: async (
+    instanceId: string,
+    payload: Partial<RewardIntegrationInstancePayload>
+  ): Promise<RewardIntegrationInstanceResponse> => {
+    return apiRequest(`/admin/reward-integrations/${instanceId}`, {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    });
+  },
+
+  testRewardIntegration: async (instanceId: string): Promise<RewardIntegrationInstanceResponse> => {
+    return apiRequest(`/admin/reward-integrations/${instanceId}/test`, {
+      method: 'POST',
+    });
+  },
+
+  deactivateRewardIntegration: async (
+    instanceId: string
+  ): Promise<RewardIntegrationInstanceResponse> => {
+    return apiRequest(`/admin/reward-integrations/${instanceId}`, {
+      method: 'DELETE',
+    });
   },
 };
 

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -129,25 +129,25 @@ const apiRequest = async <T = any>(endpoint: string, options: RequestOptions = {
       if (refreshToken) {
         try {
           await refreshTokens();
-          // Retry the original request with the new token
-          finalOptions.headers.Authorization = `Bearer ${getStoredItem('accessToken')}`;
-          const retryResponse = await fetch(url, finalOptions);
-          const data = await readJson<JsonRecord>(retryResponse);
-
-          if (!retryResponse.ok) {
-            throw new Error(
-              data.error || data.message || `HTTP error! status: ${retryResponse.status}`
-            );
-          }
-
-          return data as T;
         } catch {
-          // Refresh failed, logout user
           clearStoredItem('accessToken');
           clearStoredItem('refreshToken');
           clearStoredItem('cachedUser');
           throw new Error('Session expired. Please log in again.');
         }
+
+        // Retry the original request with the new token.
+        finalOptions.headers.Authorization = `Bearer ${getStoredItem('accessToken')}`;
+        const retryResponse = await fetch(url, finalOptions);
+        const data = await readJson<JsonRecord>(retryResponse);
+
+        if (!retryResponse.ok) {
+          throw new Error(
+            data.error || data.message || `HTTP error! status: ${retryResponse.status}`
+          );
+        }
+
+        return data as T;
       }
     }
 
@@ -182,7 +182,13 @@ const setStoredItem = (key: string, value: string): void => {
   storage.setItem(key, value);
 };
 
+let refreshPromise: Promise<AuthResponse> | null = null;
+
 const refreshTokens = async (): Promise<AuthResponse> => {
+  if (refreshPromise) {
+    return refreshPromise;
+  }
+
   const refreshToken = getStoredItem('refreshToken');
   const deviceId = getStoredItem('deviceId') || localStorage.getItem('deviceId');
 
@@ -190,27 +196,36 @@ const refreshTokens = async (): Promise<AuthResponse> => {
     throw new Error('No refresh token available');
   }
 
-  const response = await fetch(`${API_BASE_URL}/auth/refresh-token`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      refreshToken,
-      deviceId,
-    }),
-  });
+  refreshPromise = (async () => {
+    const response = await fetch(`${API_BASE_URL}/auth/refresh-token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        refreshToken,
+        deviceId,
+      }),
+    });
 
-  if (!response.ok) {
-    throw new Error('Token refresh failed');
+    if (!response.ok) {
+      throw new Error('Token refresh failed');
+    }
+
+    const data = (await response.json()) as AuthResponse;
+    localStorage.setItem('rememberMe', data.rememberMe ? 'true' : 'false');
+    setStoredItem('accessToken', data.accessToken);
+    setStoredItem('refreshToken', data.refreshToken);
+    setStoredItem('cachedUser', JSON.stringify(data.user));
+
+    return data;
+  })();
+
+  try {
+    return await refreshPromise;
+  } finally {
+    refreshPromise = null;
   }
-
-  const data = (await response.json()) as AuthResponse;
-  setStoredItem('accessToken', data.accessToken);
-  setStoredItem('refreshToken', data.refreshToken);
-  setStoredItem('cachedUser', JSON.stringify(data.user));
-
-  return data;
 };
 
 const appendPayloadToForm = (form: FormData, payload: EventFormPayload | JsonRecord): void => {
@@ -461,6 +476,13 @@ export const rewardIntegrationAPI = {
     return apiRequest('/integrations/prizeversity/link', {
       method: 'POST',
       body: JSON.stringify({ identifier, instanceId }),
+    });
+  },
+
+  verifyLink: async (code: string): Promise<RewardIntegrationLinkResponse> => {
+    return apiRequest('/integrations/prizeversity/link/verify', {
+      method: 'POST',
+      body: JSON.stringify({ code }),
     });
   },
 


### PR DESCRIPTION
This PR adds the first version of the Prizeversity-backed challenge reward flow. Admins can configure classroom-scoped Prizeversity reward instances, and users can link their AWS Student Hub account to the matching Prizeversity classroom member before accessing rewardable AWS challenges.

Prizeversity account linking now uses a verification step instead of trusting a raw email, name, or short ID match. The backend resolves the matching classroom member, sends a one-time code to the email attached to that Prizeversity account, stores only a salted hash of the pending code, and writes the permanent user link only after successful verification.

AWS challenge credential access is now gated behind a verified Prizeversity link so completions can be attributed to the correct Prizeversity user and classroom. The Account and Challenges pages were updated with reward-link status, linking and verification UI, clearer failure states, and a dismissible connected-rewards banner.

This also fixes related auth/session issues found during the integration work: legacy users with missing refresh token arrays no longer crash login, remember-me state is preserved across token rotation, concurrent frontend refreshes are single-flighted, legacy users are not routed to onboarding unless setup is explicitly incomplete, and AWS credentials are no longer returned in normal auth payloads unless the user has a verified challenge reward link.
