### PR TITLE
feat: add agnostic challenge backend foundation

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,7 @@ import mongoose from 'mongoose';
 import connectDB, { checkConnection } from './config/database';
 import adminRoutes from './routes/admin';
 import authRoutes from './routes/auth';
+import challengeRoutes from './routes/challenges';
 import discordInviteRoutes from './routes/discordInvite';
 import eventRoutes from './routes/events';
 import newsletterRoutes from './routes/newsletter';
@@ -151,6 +152,7 @@ app.use('/upload', uploadRoutes);
 app.use('/', discordInviteRoutes);
 app.use('/admin', adminRoutes);
 app.use('/events', eventRoutes);
+app.use('/challenges', challengeRoutes);
 app.use('/integrations/prizeversity', rewardIntegrationRoutes);
 app.use('/verify', verifyRoutes);
 

--- a/backend/src/controllers/challengeAdminController.ts
+++ b/backend/src/controllers/challengeAdminController.ts
@@ -1,0 +1,167 @@
+import { Request, Response } from 'express';
+
+import {
+  ChallengeServiceError,
+  archiveAdminChallenge,
+  createAdminChallenge,
+  getAdminChallenge,
+  listAdminChallengeProgress,
+  listAdminChallengeSubmissions,
+  listAdminChallenges,
+  publishAdminChallenge,
+  testAdminChallengeValidation,
+  updateAdminChallenge,
+} from '../services/challengeService';
+
+const getAdminUserId = (req: Request): string | null => req.user?.id || null;
+
+const getErrorBody = (error: unknown, fallback: string) => {
+  if (error instanceof ChallengeServiceError) {
+    return {
+      error: error.message,
+      code: error.code,
+      details: error.details,
+    };
+  }
+
+  return {
+    error: error instanceof Error ? error.message : fallback,
+  };
+};
+
+const getErrorStatus = (error: unknown, fallback = 500): number => {
+  if (error instanceof ChallengeServiceError) return error.status;
+  return fallback;
+};
+
+export const listChallenges = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const result = await listAdminChallenges({
+      status: typeof req.query.status === 'string' ? (req.query.status as any) : undefined,
+      search: typeof req.query.search === 'string' ? req.query.search : undefined,
+      page: Number(req.query.page),
+      limit: Number(req.query.limit),
+    });
+    res.json(result);
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error)).json(getErrorBody(error, 'Unable to list challenges'));
+  }
+};
+
+export const createChallenge = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const adminUserId = getAdminUserId(req);
+    if (!adminUserId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    const challenge = await createAdminChallenge(req.body || {}, adminUserId);
+    res.status(201).json({
+      message: 'Challenge created',
+      challenge,
+    });
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error, 400)).json(getErrorBody(error, 'Unable to create challenge'));
+  }
+};
+
+export const getChallenge = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const challenge = await getAdminChallenge(req.params.challengeId);
+    res.json({ challenge });
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error, 404)).json(getErrorBody(error, 'Unable to load challenge'));
+  }
+};
+
+export const updateChallenge = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const adminUserId = getAdminUserId(req);
+    if (!adminUserId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    const challenge = await updateAdminChallenge(
+      req.params.challengeId,
+      req.body || {},
+      adminUserId
+    );
+    res.json({
+      message: 'Challenge updated',
+      challenge,
+    });
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error, 400)).json(getErrorBody(error, 'Unable to update challenge'));
+  }
+};
+
+export const publishChallenge = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const adminUserId = getAdminUserId(req);
+    if (!adminUserId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    const challenge = await publishAdminChallenge(req.params.challengeId, adminUserId);
+    res.json({
+      message: 'Challenge published',
+      challenge,
+    });
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error, 400)).json(getErrorBody(error, 'Unable to publish challenge'));
+  }
+};
+
+export const archiveChallenge = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const adminUserId = getAdminUserId(req);
+    if (!adminUserId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    const challenge = await archiveAdminChallenge(req.params.challengeId, adminUserId);
+    res.json({
+      message: 'Challenge archived',
+      challenge,
+    });
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error, 400)).json(getErrorBody(error, 'Unable to archive challenge'));
+  }
+};
+
+export const listSubmissions = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const result = await listAdminChallengeSubmissions(req.params.challengeId, {
+      page: Number(req.query.page),
+      limit: Number(req.query.limit),
+    });
+    res.json(result);
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error, 400)).json(getErrorBody(error, 'Unable to list submissions'));
+  }
+};
+
+export const listProgress = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const result = await listAdminChallengeProgress(req.params.challengeId, {
+      page: Number(req.query.page),
+      limit: Number(req.query.limit),
+      status: typeof req.query.status === 'string' ? (req.query.status as any) : undefined,
+    });
+    res.json(result);
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error, 400)).json(getErrorBody(error, 'Unable to list progress'));
+  }
+};
+
+export const testValidation = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    await testAdminChallengeValidation();
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error, 501)).json(getErrorBody(error, 'Unable to test validation'));
+  }
+};

--- a/backend/src/controllers/challengeController.ts
+++ b/backend/src/controllers/challengeController.ts
@@ -1,0 +1,95 @@
+import { Request, Response } from 'express';
+
+import {
+  ChallengeServiceError,
+  getChallengeProgress,
+  getPublishedChallenge,
+  listPublishedChallenges,
+  startChallenge,
+  submitChallenge,
+} from '../services/challengeService';
+
+const getErrorBody = (error: unknown, fallback: string) => {
+  if (error instanceof ChallengeServiceError) {
+    return {
+      error: error.message,
+      code: error.code,
+      details: error.details,
+    };
+  }
+
+  return {
+    error: error instanceof Error ? error.message : fallback,
+  };
+};
+
+const getErrorStatus = (error: unknown, fallback = 500): number => {
+  if (error instanceof ChallengeServiceError) return error.status;
+  return fallback;
+};
+
+export const listChallenges = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const result = await listPublishedChallenges({
+      userId: req.user?.id,
+      tag: typeof req.query.tag === 'string' ? req.query.tag : undefined,
+      difficulty:
+        typeof req.query.difficulty === 'string' ? (req.query.difficulty as any) : undefined,
+    });
+    res.json(result);
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error)).json(getErrorBody(error, 'Unable to list challenges'));
+  }
+};
+
+export const getChallenge = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const result = await getPublishedChallenge(req.params.slug, req.user?.id);
+    res.json(result);
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error, 404)).json(getErrorBody(error, 'Unable to load challenge'));
+  }
+};
+
+export const getProgress = async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!req.user?.id) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    const result = await getChallengeProgress(req.params.slug, req.user.id);
+    res.json(result);
+  } catch (error: unknown) {
+    res
+      .status(getErrorStatus(error, 400))
+      .json(getErrorBody(error, 'Unable to load challenge progress'));
+  }
+};
+
+export const start = async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!req.user?.id) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    const result = await startChallenge(req.params.slug, req.user.id);
+    res.json(result);
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error, 400)).json(getErrorBody(error, 'Unable to start challenge'));
+  }
+};
+
+export const submit = async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!req.user?.id) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    await submitChallenge(req.params.slug, req.user.id, req.body?.payload);
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error, 400)).json(getErrorBody(error, 'Unable to submit challenge'));
+  }
+};

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -25,6 +25,58 @@ const isAccessTokenPayload = (decoded: string | jwt.JwtPayload): decoded is Acce
   return typeof decoded !== 'string' && typeof decoded.id === 'string';
 };
 
+const authenticateAccessToken = async (token: string): Promise<Express.UserPayload> => {
+  const decoded = jwt.verify(token, getJwtSecret());
+
+  if (!isAccessTokenPayload(decoded)) {
+    throw new jwt.JsonWebTokenError('Token is malformed');
+  }
+
+  const user = await User.findById(decoded.id).select('tokenVersion status');
+
+  if (!user) {
+    throw new jwt.JsonWebTokenError('Token is not valid - user not found');
+  }
+
+  const userStatus = (user.status || 'active') as UserStatus;
+
+  if (userStatus !== 'active') {
+    throw new jwt.JsonWebTokenError('Account is not active');
+  }
+
+  if (decoded.tokenVersion !== user.tokenVersion) {
+    throw new jwt.JsonWebTokenError('Token has been revoked');
+  }
+
+  return {
+    id: decoded.id,
+    email: decoded.email,
+    tokenVersion: decoded.tokenVersion,
+  };
+};
+
+const sendJwtError = (res: Response, err: unknown): void => {
+  if (err instanceof jwt.TokenExpiredError) {
+    res.status(401).json({
+      error: 'Token has expired',
+      expired: true,
+    });
+    return;
+  }
+
+  if (err instanceof jwt.JsonWebTokenError) {
+    res.status(401).json({
+      error: err.message || 'Token is malformed',
+    });
+    return;
+  }
+
+  log.error('jwt verification error.', err);
+  res.status(401).json({
+    error: 'Token is not valid',
+  });
+};
+
 const checkJwt = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const authHeader = req.header('Authorization');
   const token = authHeader && authHeader.split(' ')[1];
@@ -37,67 +89,31 @@ const checkJwt = async (req: Request, res: Response, next: NextFunction): Promis
   }
 
   try {
-    const decoded = jwt.verify(token, getJwtSecret());
-
-    if (!isAccessTokenPayload(decoded)) {
-      res.status(401).json({
-        error: 'Token is malformed',
-      });
-      return;
-    }
-
-    const user = await User.findById(decoded.id).select('tokenVersion status');
-
-    if (!user) {
-      res.status(401).json({
-        error: 'Token is not valid - user not found',
-      });
-      return;
-    }
-
-    const userStatus = (user.status || 'active') as UserStatus;
-
-    if (userStatus !== 'active') {
-      res.status(401).json({
-        error: 'Account is not active',
-      });
-      return;
-    }
-
-    if (decoded.tokenVersion !== user.tokenVersion) {
-      res.status(401).json({
-        error: 'Token has been revoked',
-      });
-      return;
-    }
-
-    req.user = {
-      id: decoded.id,
-      email: decoded.email,
-      tokenVersion: decoded.tokenVersion,
-    };
-
+    req.user = await authenticateAccessToken(token);
     next();
   } catch (err: unknown) {
-    if (err instanceof jwt.TokenExpiredError) {
-      res.status(401).json({
-        error: 'Token has expired',
-        expired: true,
-      });
-      return;
-    }
+    sendJwtError(res, err);
+  }
+};
 
-    if (err instanceof jwt.JsonWebTokenError) {
-      res.status(401).json({
-        error: 'Token is malformed',
-      });
-      return;
-    }
+export const optionalJwt = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  const authHeader = req.header('Authorization');
+  const token = authHeader && authHeader.split(' ')[1];
 
-    log.error('jwt verification error.', err);
-    res.status(401).json({
-      error: 'Token is not valid',
-    });
+  if (!token) {
+    next();
+    return;
+  }
+
+  try {
+    req.user = await authenticateAccessToken(token);
+    next();
+  } catch (err: unknown) {
+    sendJwtError(res, err);
   }
 };
 

--- a/backend/src/models/Challenge.ts
+++ b/backend/src/models/Challenge.ts
@@ -1,0 +1,226 @@
+import mongoose, { HydratedDocument, Model, Schema, Types } from 'mongoose';
+
+export type ChallengeStatus = 'draft' | 'published' | 'archived';
+export type ChallengeKind = 'single' | 'multi_part';
+export type ChallengeDifficulty = 'easy' | 'medium' | 'hard' | 'expert';
+export type ChallengeXpMode = 'none' | 'classroom' | 'custom';
+
+export interface IChallengeRewardConfig {
+  enabled: boolean;
+  bits: number;
+  xpAmount?: number;
+  xpMode?: ChallengeXpMode;
+  activityName?: string;
+  description?: string;
+  stats?: {
+    multiplier?: number;
+    luck?: number;
+    shield?: number;
+    discount?: number;
+  };
+  applyGroupMultipliers?: boolean;
+  applyPersonalMultipliers?: boolean;
+}
+
+export interface IChallenge {
+  key: string;
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  instructions?: string;
+  status: ChallengeStatus;
+  kind: ChallengeKind;
+  difficulty: ChallengeDifficulty;
+  estimatedMinutes?: number;
+  tags: string[];
+  version: number;
+  publishedAt?: Date | null;
+  archivedAt?: Date | null;
+  startsAt?: Date | null;
+  endsAt?: Date | null;
+  maxAttempts?: number;
+  validation: Record<string, unknown>;
+  reward: IChallengeRewardConfig;
+  createdBy: Types.ObjectId;
+  updatedBy?: Types.ObjectId;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type IChallengeDocument = HydratedDocument<IChallenge>;
+type ChallengeModel = Model<IChallenge>;
+
+const challengeRewardSchema = new Schema<IChallengeRewardConfig>(
+  {
+    enabled: {
+      type: Boolean,
+      default: false,
+    },
+    bits: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
+    xpAmount: {
+      type: Number,
+      min: 0,
+    },
+    xpMode: {
+      type: String,
+      enum: ['none', 'classroom', 'custom'],
+      default: 'custom',
+    },
+    activityName: {
+      type: String,
+      trim: true,
+      maxlength: 160,
+    },
+    description: {
+      type: String,
+      trim: true,
+      maxlength: 500,
+    },
+    stats: {
+      multiplier: { type: Number },
+      luck: { type: Number },
+      shield: { type: Number },
+      discount: { type: Number },
+    },
+    applyGroupMultipliers: {
+      type: Boolean,
+      default: true,
+    },
+    applyPersonalMultipliers: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  { _id: false }
+);
+
+const challengeSchema = new Schema<IChallenge, ChallengeModel>(
+  {
+    key: {
+      type: String,
+      required: true,
+      unique: true,
+      trim: true,
+      lowercase: true,
+      maxlength: 120,
+      match: /^[a-z0-9][a-z0-9-_]*$/,
+      index: true,
+    },
+    slug: {
+      type: String,
+      required: true,
+      unique: true,
+      trim: true,
+      lowercase: true,
+      maxlength: 140,
+      match: /^[a-z0-9][a-z0-9-]*$/,
+      index: true,
+    },
+    title: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 160,
+    },
+    summary: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 300,
+    },
+    description: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 5000,
+    },
+    instructions: {
+      type: String,
+      trim: true,
+      maxlength: 10000,
+    },
+    status: {
+      type: String,
+      enum: ['draft', 'published', 'archived'],
+      default: 'draft',
+      index: true,
+    },
+    kind: {
+      type: String,
+      enum: ['single', 'multi_part'],
+      default: 'single',
+    },
+    difficulty: {
+      type: String,
+      enum: ['easy', 'medium', 'hard', 'expert'],
+      default: 'easy',
+      index: true,
+    },
+    estimatedMinutes: {
+      type: Number,
+      min: 1,
+    },
+    tags: {
+      type: [String],
+      default: [],
+      index: true,
+    },
+    version: {
+      type: Number,
+      default: 1,
+      min: 1,
+    },
+    publishedAt: {
+      type: Date,
+      default: null,
+    },
+    archivedAt: {
+      type: Date,
+      default: null,
+    },
+    startsAt: {
+      type: Date,
+      default: null,
+    },
+    endsAt: {
+      type: Date,
+      default: null,
+    },
+    maxAttempts: {
+      type: Number,
+      min: 1,
+    },
+    validation: {
+      type: Schema.Types.Mixed,
+      required: true,
+    },
+    reward: {
+      type: challengeRewardSchema,
+      default: () => ({ enabled: false, bits: 0 }),
+    },
+    createdBy: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    updatedBy: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+challengeSchema.index({ status: 1, startsAt: 1, endsAt: 1 });
+
+const Challenge = mongoose.model<IChallenge, ChallengeModel>('Challenge', challengeSchema);
+
+export default Challenge;

--- a/backend/src/models/ChallengeProgress.ts
+++ b/backend/src/models/ChallengeProgress.ts
@@ -1,0 +1,115 @@
+import mongoose, { HydratedDocument, Model, Schema, Types } from 'mongoose';
+
+export type ChallengeProgressStatus =
+  | 'not_started'
+  | 'in_progress'
+  | 'completed'
+  | 'reward_pending'
+  | 'reward_sent'
+  | 'reward_failed';
+
+export interface IChallengeProgress {
+  userId: Types.ObjectId;
+  challengeId: Types.ObjectId;
+  challengeKey: string;
+  challengeVersion: number;
+  status: ChallengeProgressStatus;
+  attemptCount: number;
+  startedAt?: Date | null;
+  lastSubmittedAt?: Date | null;
+  completedAt?: Date | null;
+  rewardEmissionId?: Types.ObjectId | null;
+  completionEventId?: string;
+  lastValidationMessage?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type IChallengeProgressDocument = HydratedDocument<IChallengeProgress>;
+type ChallengeProgressModel = Model<IChallengeProgress>;
+
+const challengeProgressSchema = new Schema<IChallengeProgress, ChallengeProgressModel>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    challengeId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Challenge',
+      required: true,
+      index: true,
+    },
+    challengeKey: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+    },
+    challengeVersion: {
+      type: Number,
+      required: true,
+      min: 1,
+    },
+    status: {
+      type: String,
+      enum: [
+        'not_started',
+        'in_progress',
+        'completed',
+        'reward_pending',
+        'reward_sent',
+        'reward_failed',
+      ],
+      default: 'not_started',
+      index: true,
+    },
+    attemptCount: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
+    startedAt: {
+      type: Date,
+      default: null,
+    },
+    lastSubmittedAt: {
+      type: Date,
+      default: null,
+    },
+    completedAt: {
+      type: Date,
+      default: null,
+    },
+    rewardEmissionId: {
+      type: Schema.Types.ObjectId,
+      ref: 'RewardIntegrationEmission',
+      default: null,
+    },
+    completionEventId: {
+      type: String,
+      trim: true,
+    },
+    lastValidationMessage: {
+      type: String,
+      trim: true,
+      maxlength: 500,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+challengeProgressSchema.index({ userId: 1, challengeId: 1 }, { unique: true });
+challengeProgressSchema.index({ userId: 1, status: 1 });
+challengeProgressSchema.index({ completionEventId: 1 }, { unique: true, sparse: true });
+
+const ChallengeProgress = mongoose.model<IChallengeProgress, ChallengeProgressModel>(
+  'ChallengeProgress',
+  challengeProgressSchema
+);
+
+export default ChallengeProgress;

--- a/backend/src/models/ChallengeSubmission.ts
+++ b/backend/src/models/ChallengeSubmission.ts
@@ -1,0 +1,86 @@
+import mongoose, { HydratedDocument, Model, Schema, Types } from 'mongoose';
+
+export type ChallengeSubmissionStatus = 'accepted' | 'rejected' | 'error';
+
+export interface IChallengeSubmission {
+  userId: Types.ObjectId;
+  challengeId: Types.ObjectId;
+  progressId: Types.ObjectId;
+  challengeKey: string;
+  validatorType: string;
+  status: ChallengeSubmissionStatus;
+  submittedPayloadPreview: Record<string, unknown>;
+  validationResult: Record<string, unknown>;
+  message?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type IChallengeSubmissionDocument = HydratedDocument<IChallengeSubmission>;
+type ChallengeSubmissionModel = Model<IChallengeSubmission>;
+
+const challengeSubmissionSchema = new Schema<IChallengeSubmission, ChallengeSubmissionModel>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    challengeId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Challenge',
+      required: true,
+      index: true,
+    },
+    progressId: {
+      type: Schema.Types.ObjectId,
+      ref: 'ChallengeProgress',
+      required: true,
+      index: true,
+    },
+    challengeKey: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+    },
+    validatorType: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    status: {
+      type: String,
+      enum: ['accepted', 'rejected', 'error'],
+      required: true,
+      index: true,
+    },
+    submittedPayloadPreview: {
+      type: Schema.Types.Mixed,
+      default: {},
+    },
+    validationResult: {
+      type: Schema.Types.Mixed,
+      default: {},
+    },
+    message: {
+      type: String,
+      trim: true,
+      maxlength: 1000,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+challengeSubmissionSchema.index({ userId: 1, challengeId: 1, createdAt: -1 });
+challengeSubmissionSchema.index({ progressId: 1, createdAt: -1 });
+
+const ChallengeSubmission = mongoose.model<IChallengeSubmission, ChallengeSubmissionModel>(
+  'ChallengeSubmission',
+  challengeSubmissionSchema
+);
+
+export default ChallengeSubmission;

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 
 import * as adminController from '../controllers/adminController';
+import * as challengeAdminController from '../controllers/challengeAdminController';
 import * as rewardIntegrationAdminController from '../controllers/rewardIntegrationAdminController';
 import { canManageUser, requireAdmin, requireModerator } from '../middleware/adminAuth';
 
@@ -17,6 +18,35 @@ router.get('/email-queue/stats', requireAdmin, adminController.getEmailQueueStat
 router.get('/email-queue/entries', requireAdmin, adminController.getEmailQueueEntries);
 router.post('/email-queue/:queueId/retry', requireAdmin, adminController.retryQueuedEmail);
 router.post('/email-queue/process', requireAdmin, adminController.processQueue);
+router.get('/challenges', requireAdmin, challengeAdminController.listChallenges);
+router.post('/challenges', requireAdmin, challengeAdminController.createChallenge);
+router.get('/challenges/:challengeId', requireAdmin, challengeAdminController.getChallenge);
+router.patch('/challenges/:challengeId', requireAdmin, challengeAdminController.updateChallenge);
+router.post(
+  '/challenges/:challengeId/publish',
+  requireAdmin,
+  challengeAdminController.publishChallenge
+);
+router.post(
+  '/challenges/:challengeId/archive',
+  requireAdmin,
+  challengeAdminController.archiveChallenge
+);
+router.get(
+  '/challenges/:challengeId/submissions',
+  requireAdmin,
+  challengeAdminController.listSubmissions
+);
+router.get(
+  '/challenges/:challengeId/progress',
+  requireAdmin,
+  challengeAdminController.listProgress
+);
+router.post(
+  '/challenges/:challengeId/test-validation',
+  requireAdmin,
+  challengeAdminController.testValidation
+);
 router.get('/reward-integrations', requireAdmin, rewardIntegrationAdminController.listInstances);
 router.post('/reward-integrations', requireAdmin, rewardIntegrationAdminController.createInstance);
 router.put(

--- a/backend/src/routes/challenges.ts
+++ b/backend/src/routes/challenges.ts
@@ -1,0 +1,14 @@
+import express from 'express';
+
+import * as challengeController from '../controllers/challengeController';
+import checkJwt, { optionalJwt } from '../middleware/auth';
+
+const router = express.Router();
+
+router.get('/', optionalJwt, challengeController.listChallenges);
+router.get('/:slug', optionalJwt, challengeController.getChallenge);
+router.get('/:slug/progress', checkJwt, challengeController.getProgress);
+router.post('/:slug/start', checkJwt, challengeController.start);
+router.post('/:slug/submit', checkJwt, challengeController.submit);
+
+export default router;

--- a/backend/src/routes/rewardIntegration.ts
+++ b/backend/src/routes/rewardIntegration.ts
@@ -16,6 +16,11 @@ const getAuthenticatedUser = async (req: Request) => {
   return User.findById(req.user.id);
 };
 
+const getErrorStatus = (error: unknown, fallback = 400): number => {
+  const status = (error as { status?: unknown })?.status;
+  return typeof status === 'number' && status >= 400 && status < 600 ? status : fallback;
+};
+
 router.get('/status', checkJwt, async (req: Request, res: Response): Promise<void> => {
   try {
     const user = await getAuthenticatedUser(req);
@@ -51,7 +56,7 @@ router.post('/link', checkJwt, async (req: Request, res: Response): Promise<void
       user: user.toSafeObject(),
     });
   } catch (error: unknown) {
-    res.status(400).json({
+    res.status(getErrorStatus(error)).json({
       error: error instanceof Error ? error.message : 'Unable to link Prizeversity account',
     });
   }
@@ -74,7 +79,7 @@ router.post('/link/verify', checkJwt, async (req: Request, res: Response): Promi
       user: user.toSafeObject(),
     });
   } catch (error: unknown) {
-    res.status(400).json({
+    res.status(getErrorStatus(error)).json({
       error: error instanceof Error ? error.message : 'Unable to verify Prizeversity link code',
     });
   }

--- a/backend/src/services/challengeService.ts
+++ b/backend/src/services/challengeService.ts
@@ -1,0 +1,819 @@
+import { Types } from 'mongoose';
+
+import Challenge, {
+  ChallengeDifficulty,
+  ChallengeKind,
+  ChallengeStatus,
+  ChallengeXpMode,
+  IChallengeDocument,
+  IChallengeRewardConfig,
+} from '../models/Challenge';
+import ChallengeProgress, {
+  ChallengeProgressStatus,
+  IChallengeProgressDocument,
+} from '../models/ChallengeProgress';
+import ChallengeSubmission from '../models/ChallengeSubmission';
+import User from '../models/User';
+import { getPrizeversityStatus } from './rewardIntegrationService';
+
+export type ChallengeErrorCode =
+  | 'CHALLENGE_NOT_FOUND'
+  | 'CHALLENGE_NOT_PUBLISHED'
+  | 'REWARD_LINK_REQUIRED'
+  | 'MAX_ATTEMPTS_REACHED'
+  | 'VALIDATION_FAILED'
+  | 'VALIDATOR_ERROR'
+  | 'INVALID_CHALLENGE_INPUT';
+
+export class ChallengeServiceError extends Error {
+  status: number;
+  code: ChallengeErrorCode;
+  details?: Record<string, unknown>;
+
+  constructor(
+    message: string,
+    code: ChallengeErrorCode,
+    status = 400,
+    details?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = 'ChallengeServiceError';
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+interface ChallengeListOptions {
+  userId?: string;
+  tag?: string;
+  difficulty?: ChallengeDifficulty;
+}
+
+interface AdminChallengeListOptions {
+  status?: ChallengeStatus;
+  search?: string;
+  limit?: number;
+  page?: number;
+}
+
+interface ListResult<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+interface RewardLinkSummary {
+  required: boolean;
+  linked: boolean;
+  configured: boolean;
+}
+
+interface ChallengeMutationInput {
+  key?: string;
+  slug?: string;
+  title?: string;
+  summary?: string;
+  description?: string;
+  instructions?: string;
+  status?: ChallengeStatus;
+  kind?: ChallengeKind;
+  difficulty?: ChallengeDifficulty;
+  estimatedMinutes?: number;
+  tags?: unknown;
+  startsAt?: string | Date | null;
+  endsAt?: string | Date | null;
+  maxAttempts?: number | null;
+  validation?: Record<string, unknown>;
+  reward?: Partial<IChallengeRewardConfig>;
+}
+
+const challengeStatuses: ChallengeStatus[] = ['draft', 'published', 'archived'];
+const challengeKinds: ChallengeKind[] = ['single', 'multi_part'];
+const challengeDifficulties: ChallengeDifficulty[] = ['easy', 'medium', 'hard', 'expert'];
+const xpModes: ChallengeXpMode[] = ['none', 'classroom', 'custom'];
+const completedStatuses: ChallengeProgressStatus[] = [
+  'completed',
+  'reward_pending',
+  'reward_sent',
+  'reward_failed',
+];
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const cleanString = (value: unknown): string => {
+  return typeof value === 'string' ? value.trim() : '';
+};
+
+const slugify = (value: string): string => {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 120);
+};
+
+const keyify = (value: string): string => {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 100);
+};
+
+const parseDate = (value: string | Date | null | undefined): Date | null | undefined => {
+  if (value === null) return null;
+  if (value === undefined || value === '') return undefined;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new ChallengeServiceError('Invalid challenge date.', 'INVALID_CHALLENGE_INPUT', 400, {
+      value,
+    });
+  }
+  return date;
+};
+
+const normalizeTags = (tags: unknown): string[] => {
+  if (!Array.isArray(tags)) return [];
+
+  return Array.from(
+    new Set(
+      tags
+        .map((tag) => cleanString(tag).toLowerCase())
+        .filter(Boolean)
+        .slice(0, 20)
+    )
+  );
+};
+
+const normalizeNumber = (value: unknown): number | undefined => {
+  if (value === null || value === undefined || value === '') return undefined;
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : undefined;
+};
+
+const normalizeValidation = (
+  validation: unknown,
+  required: boolean
+): Record<string, unknown> | undefined => {
+  if (!isRecord(validation)) {
+    if (required) {
+      throw new ChallengeServiceError(
+        'Challenge validation config is required.',
+        'INVALID_CHALLENGE_INPUT'
+      );
+    }
+    return undefined;
+  }
+
+  const type = cleanString(validation.type);
+  if (!type) {
+    throw new ChallengeServiceError(
+      'Challenge validation type is required.',
+      'INVALID_CHALLENGE_INPUT'
+    );
+  }
+
+  return {
+    ...validation,
+    type,
+  };
+};
+
+const normalizeReward = (reward: unknown): IChallengeRewardConfig => {
+  if (!isRecord(reward)) {
+    return {
+      enabled: false,
+      bits: 0,
+      xpMode: 'custom',
+      applyGroupMultipliers: true,
+      applyPersonalMultipliers: true,
+    };
+  }
+
+  const bits = normalizeNumber(reward.bits);
+  const xpAmount = normalizeNumber(reward.xpAmount);
+  const xpMode = xpModes.includes(reward.xpMode as ChallengeXpMode)
+    ? (reward.xpMode as ChallengeXpMode)
+    : 'custom';
+  const stats = isRecord(reward.stats)
+    ? {
+        multiplier: normalizeNumber(reward.stats.multiplier),
+        luck: normalizeNumber(reward.stats.luck),
+        shield: normalizeNumber(reward.stats.shield),
+        discount: normalizeNumber(reward.stats.discount),
+      }
+    : undefined;
+
+  return {
+    enabled: Boolean(reward.enabled),
+    bits: bits && bits > 0 ? bits : 0,
+    xpAmount: xpAmount && xpAmount > 0 ? xpAmount : undefined,
+    xpMode,
+    activityName: cleanString(reward.activityName) || undefined,
+    description: cleanString(reward.description) || undefined,
+    stats,
+    applyGroupMultipliers:
+      typeof reward.applyGroupMultipliers === 'boolean' ? reward.applyGroupMultipliers : true,
+    applyPersonalMultipliers:
+      typeof reward.applyPersonalMultipliers === 'boolean' ? reward.applyPersonalMultipliers : true,
+  };
+};
+
+const normalizeExistingReward = (
+  current: IChallengeRewardConfig,
+  update: unknown
+): IChallengeRewardConfig => {
+  if (!isRecord(update)) return current;
+  return normalizeReward({
+    ...current,
+    ...update,
+    stats: isRecord(update.stats) ? update.stats : current.stats,
+  });
+};
+
+const isPublishedNowQuery = () => {
+  const now = new Date();
+  return {
+    status: 'published',
+    $and: [
+      { $or: [{ startsAt: null }, { startsAt: { $exists: false } }, { startsAt: { $lte: now } }] },
+      { $or: [{ endsAt: null }, { endsAt: { $exists: false } }, { endsAt: { $gte: now } }] },
+    ],
+  };
+};
+
+const getValidatorType = (challenge: IChallengeDocument): string => {
+  return cleanString(challenge.validation?.type) || 'unknown';
+};
+
+const toRewardPreview = (reward: IChallengeRewardConfig) => ({
+  enabled: Boolean(reward?.enabled),
+  bits: reward?.bits || 0,
+  xpAmount: reward?.xpAmount,
+  xpMode: reward?.xpMode || 'custom',
+});
+
+const toProgressDto = (progress: IChallengeProgressDocument | null) => {
+  if (!progress) {
+    return {
+      status: 'not_started' as ChallengeProgressStatus,
+      attemptCount: 0,
+      startedAt: null,
+      lastSubmittedAt: null,
+      completedAt: null,
+      rewardEmissionId: null,
+      completionEventId: undefined,
+      lastValidationMessage: undefined,
+    };
+  }
+
+  return {
+    id: String(progress._id),
+    challengeId: String(progress.challengeId),
+    challengeKey: progress.challengeKey,
+    challengeVersion: progress.challengeVersion,
+    status: progress.status,
+    attemptCount: progress.attemptCount,
+    startedAt: progress.startedAt,
+    lastSubmittedAt: progress.lastSubmittedAt,
+    completedAt: progress.completedAt,
+    rewardEmissionId: progress.rewardEmissionId?.toString() || null,
+    completionEventId: progress.completionEventId,
+    lastValidationMessage: progress.lastValidationMessage,
+    createdAt: progress.createdAt,
+    updatedAt: progress.updatedAt,
+  };
+};
+
+const toPublicChallengeDto = (
+  challenge: IChallengeDocument,
+  progress?: IChallengeProgressDocument | null
+) => ({
+  id: String(challenge._id),
+  key: challenge.key,
+  slug: challenge.slug,
+  title: challenge.title,
+  summary: challenge.summary,
+  description: challenge.description,
+  instructions: challenge.instructions,
+  kind: challenge.kind,
+  difficulty: challenge.difficulty,
+  estimatedMinutes: challenge.estimatedMinutes,
+  tags: challenge.tags,
+  version: challenge.version,
+  startsAt: challenge.startsAt,
+  endsAt: challenge.endsAt,
+  reward: toRewardPreview(challenge.reward),
+  progress: progress === undefined ? undefined : toProgressDto(progress),
+});
+
+const toAdminChallengeDto = (challenge: IChallengeDocument) => ({
+  ...toPublicChallengeDto(challenge),
+  status: challenge.status,
+  validation: challenge.validation,
+  reward: challenge.reward,
+  maxAttempts: challenge.maxAttempts,
+  publishedAt: challenge.publishedAt,
+  archivedAt: challenge.archivedAt,
+  createdBy: challenge.createdBy?.toString(),
+  updatedBy: challenge.updatedBy?.toString(),
+  createdAt: challenge.createdAt,
+  updatedAt: challenge.updatedAt,
+});
+
+const toSubmissionDto = (submission: any) => ({
+  id: String(submission._id),
+  userId: submission.userId?.toString(),
+  challengeId: submission.challengeId?.toString(),
+  progressId: submission.progressId?.toString(),
+  challengeKey: submission.challengeKey,
+  validatorType: submission.validatorType,
+  status: submission.status,
+  submittedPayloadPreview: submission.submittedPayloadPreview,
+  validationResult: submission.validationResult,
+  message: submission.message,
+  createdAt: submission.createdAt,
+  updatedAt: submission.updatedAt,
+});
+
+const getRewardLinkSummary = async (userId?: string): Promise<RewardLinkSummary> => {
+  if (!userId || !Types.ObjectId.isValid(userId)) {
+    return { required: true, linked: false, configured: false };
+  }
+
+  const user = await User.findById(userId);
+  const status = await getPrizeversityStatus(user);
+
+  return {
+    required: true,
+    linked: status.linked,
+    configured: status.configured,
+  };
+};
+
+const ensurePublishedChallenge = async (slug: string): Promise<IChallengeDocument> => {
+  const challenge = await Challenge.findOne({
+    slug: slugify(slug),
+    ...isPublishedNowQuery(),
+  });
+
+  if (!challenge) {
+    throw new ChallengeServiceError('Challenge not found.', 'CHALLENGE_NOT_FOUND', 404);
+  }
+
+  return challenge;
+};
+
+const ensureChallengeById = async (challengeId: string): Promise<IChallengeDocument> => {
+  if (!Types.ObjectId.isValid(challengeId)) {
+    throw new ChallengeServiceError('Challenge not found.', 'CHALLENGE_NOT_FOUND', 404);
+  }
+
+  const challenge = await Challenge.findById(challengeId);
+  if (!challenge) {
+    throw new ChallengeServiceError('Challenge not found.', 'CHALLENGE_NOT_FOUND', 404);
+  }
+
+  return challenge;
+};
+
+const getOrCreateProgress = async (
+  challenge: IChallengeDocument,
+  userId: string
+): Promise<IChallengeProgressDocument> => {
+  const userObjectId = new Types.ObjectId(userId);
+  let progress = await ChallengeProgress.findOne({
+    userId: userObjectId,
+    challengeId: challenge._id,
+  });
+
+  if (!progress) {
+    progress = await ChallengeProgress.create({
+      userId: userObjectId,
+      challengeId: challenge._id,
+      challengeKey: challenge.key,
+      challengeVersion: challenge.version,
+      status: 'in_progress',
+      attemptCount: 0,
+      startedAt: new Date(),
+    });
+    return progress;
+  }
+
+  if (progress.status === 'not_started') {
+    progress.status = 'in_progress';
+    progress.startedAt = progress.startedAt || new Date();
+    await progress.save();
+  }
+
+  return progress;
+};
+
+const sanitizePayloadPreview = (payload: unknown): Record<string, unknown> => {
+  if (!isRecord(payload)) return {};
+
+  return Object.fromEntries(
+    Object.entries(payload).map(([key, value]) => {
+      const lowerKey = key.toLowerCase();
+      if (
+        lowerKey.includes('secret') ||
+        lowerKey.includes('password') ||
+        lowerKey.includes('token') ||
+        lowerKey.includes('key')
+      ) {
+        return [key, '[redacted]'];
+      }
+
+      if (typeof value === 'string') {
+        return [key, value.length > 80 ? `${value.slice(0, 80)}...` : value];
+      }
+
+      if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
+        return [key, value];
+      }
+
+      return [key, '[object]'];
+    })
+  );
+};
+
+const normalizePagination = (page?: number, limit?: number) => {
+  const normalizedPage = Math.max(1, Number(page) || 1);
+  const normalizedLimit = Math.min(100, Math.max(1, Number(limit) || 25));
+  return {
+    page: normalizedPage,
+    limit: normalizedLimit,
+    skip: (normalizedPage - 1) * normalizedLimit,
+  };
+};
+
+export const listPublishedChallenges = async (
+  options: ChallengeListOptions = {}
+): Promise<{
+  challenges: ReturnType<typeof toPublicChallengeDto>[];
+  rewardLink: RewardLinkSummary;
+}> => {
+  const query: Record<string, unknown> = isPublishedNowQuery();
+
+  if (options.tag) query.tags = cleanString(options.tag).toLowerCase();
+  if (options.difficulty && challengeDifficulties.includes(options.difficulty)) {
+    query.difficulty = options.difficulty;
+  }
+
+  const challenges = await Challenge.find(query).sort({ publishedAt: -1, createdAt: -1 });
+  const progressByChallengeId = new Map<string, IChallengeProgressDocument>();
+
+  if (options.userId && challenges.length) {
+    const progressRecords = await ChallengeProgress.find({
+      userId: new Types.ObjectId(options.userId),
+      challengeId: { $in: challenges.map((challenge) => challenge._id) },
+    });
+
+    progressRecords.forEach((progress) => {
+      progressByChallengeId.set(progress.challengeId.toString(), progress);
+    });
+  }
+
+  return {
+    challenges: challenges.map((challenge) =>
+      toPublicChallengeDto(challenge, progressByChallengeId.get(String(challenge._id)) || null)
+    ),
+    rewardLink: await getRewardLinkSummary(options.userId),
+  };
+};
+
+export const getPublishedChallenge = async (
+  slug: string,
+  userId?: string
+): Promise<{
+  challenge: ReturnType<typeof toPublicChallengeDto>;
+  rewardLink: RewardLinkSummary;
+}> => {
+  const challenge = await ensurePublishedChallenge(slug);
+  const progress =
+    userId && Types.ObjectId.isValid(userId)
+      ? await ChallengeProgress.findOne({
+          userId: new Types.ObjectId(userId),
+          challengeId: challenge._id,
+        })
+      : null;
+
+  return {
+    challenge: toPublicChallengeDto(challenge, userId ? progress || null : undefined),
+    rewardLink: await getRewardLinkSummary(userId),
+  };
+};
+
+export const getChallengeProgress = async (
+  slug: string,
+  userId: string
+): Promise<{
+  challenge: ReturnType<typeof toPublicChallengeDto>;
+  progress: ReturnType<typeof toProgressDto>;
+}> => {
+  const challenge = await ensurePublishedChallenge(slug);
+  const progress = await ChallengeProgress.findOne({
+    userId: new Types.ObjectId(userId),
+    challengeId: challenge._id,
+  });
+
+  return {
+    challenge: toPublicChallengeDto(challenge),
+    progress: toProgressDto(progress),
+  };
+};
+
+export const startChallenge = async (
+  slug: string,
+  userId: string
+): Promise<{
+  challenge: ReturnType<typeof toPublicChallengeDto>;
+  progress: ReturnType<typeof toProgressDto>;
+}> => {
+  const challenge = await ensurePublishedChallenge(slug);
+  const progress = await getOrCreateProgress(challenge, userId);
+
+  return {
+    challenge: toPublicChallengeDto(challenge),
+    progress: toProgressDto(progress),
+  };
+};
+
+export const submitChallenge = async (
+  slug: string,
+  userId: string,
+  payload: unknown
+): Promise<never> => {
+  const challenge = await ensurePublishedChallenge(slug);
+  const progress = await getOrCreateProgress(challenge, userId);
+
+  if (completedStatuses.includes(progress.status)) {
+    throw new ChallengeServiceError('Challenge is already completed.', 'VALIDATION_FAILED', 409, {
+      progress: toProgressDto(progress),
+    });
+  }
+
+  if (challenge.maxAttempts && progress.attemptCount >= challenge.maxAttempts) {
+    throw new ChallengeServiceError(
+      'Maximum challenge attempts reached.',
+      'MAX_ATTEMPTS_REACHED',
+      429,
+      { progress: toProgressDto(progress) }
+    );
+  }
+
+  progress.attemptCount += 1;
+  progress.lastSubmittedAt = new Date();
+  progress.lastValidationMessage = 'Challenge validation engine is not implemented yet.';
+  await progress.save();
+
+  await ChallengeSubmission.create({
+    userId: new Types.ObjectId(userId),
+    challengeId: challenge._id,
+    progressId: progress._id,
+    challengeKey: challenge.key,
+    validatorType: getValidatorType(challenge),
+    status: 'error',
+    submittedPayloadPreview: sanitizePayloadPreview(payload),
+    validationResult: {
+      code: 'VALIDATOR_NOT_IMPLEMENTED',
+    },
+    message: 'Challenge validation engine is not implemented yet.',
+  });
+
+  throw new ChallengeServiceError(
+    'Challenge validation engine is not implemented yet.',
+    'VALIDATOR_ERROR',
+    501,
+    { progress: toProgressDto(progress) }
+  );
+};
+
+export const listAdminChallenges = async (
+  options: AdminChallengeListOptions = {}
+): Promise<ListResult<ReturnType<typeof toAdminChallengeDto>>> => {
+  const { page, limit, skip } = normalizePagination(options.page, options.limit);
+  const query: Record<string, unknown> = {};
+
+  if (options.status && challengeStatuses.includes(options.status)) {
+    query.status = options.status;
+  }
+
+  if (options.search) {
+    const search = cleanString(options.search);
+    query.$or = [
+      { title: { $regex: search, $options: 'i' } },
+      { key: { $regex: search, $options: 'i' } },
+      { slug: { $regex: search, $options: 'i' } },
+    ];
+  }
+
+  const [items, total] = await Promise.all([
+    Challenge.find(query).sort({ updatedAt: -1 }).skip(skip).limit(limit),
+    Challenge.countDocuments(query),
+  ]);
+
+  return {
+    items: items.map(toAdminChallengeDto),
+    total,
+    page,
+    limit,
+  };
+};
+
+export const getAdminChallenge = async (
+  challengeId: string
+): Promise<ReturnType<typeof toAdminChallengeDto>> => {
+  return toAdminChallengeDto(await ensureChallengeById(challengeId));
+};
+
+export const createAdminChallenge = async (
+  input: ChallengeMutationInput,
+  adminUserId: string
+): Promise<ReturnType<typeof toAdminChallengeDto>> => {
+  const title = cleanString(input.title);
+  const summary = cleanString(input.summary);
+  const description = cleanString(input.description);
+
+  if (!title) {
+    throw new ChallengeServiceError('Challenge title is required.', 'INVALID_CHALLENGE_INPUT');
+  }
+  if (!summary) {
+    throw new ChallengeServiceError('Challenge summary is required.', 'INVALID_CHALLENGE_INPUT');
+  }
+  if (!description) {
+    throw new ChallengeServiceError(
+      'Challenge description is required.',
+      'INVALID_CHALLENGE_INPUT'
+    );
+  }
+
+  const slug = slugify(input.slug || title);
+  const key = keyify(input.key || slug || title);
+
+  if (!slug || !key) {
+    throw new ChallengeServiceError(
+      'Challenge slug and key are required.',
+      'INVALID_CHALLENGE_INPUT'
+    );
+  }
+
+  const status = challengeStatuses.includes(input.status as ChallengeStatus)
+    ? (input.status as ChallengeStatus)
+    : 'draft';
+  const startsAt = parseDate(input.startsAt);
+  const endsAt = parseDate(input.endsAt);
+  const now = new Date();
+
+  const challenge = await Challenge.create({
+    key,
+    slug,
+    title,
+    summary,
+    description,
+    instructions: cleanString(input.instructions) || undefined,
+    status,
+    kind: challengeKinds.includes(input.kind as ChallengeKind) ? input.kind : 'single',
+    difficulty: challengeDifficulties.includes(input.difficulty as ChallengeDifficulty)
+      ? input.difficulty
+      : 'easy',
+    estimatedMinutes: normalizeNumber(input.estimatedMinutes),
+    tags: normalizeTags(input.tags),
+    version: 1,
+    publishedAt: status === 'published' ? now : null,
+    archivedAt: status === 'archived' ? now : null,
+    startsAt,
+    endsAt,
+    maxAttempts: normalizeNumber(input.maxAttempts),
+    validation: normalizeValidation(input.validation, true),
+    reward: normalizeReward(input.reward),
+    createdBy: new Types.ObjectId(adminUserId),
+  });
+
+  return toAdminChallengeDto(challenge);
+};
+
+export const updateAdminChallenge = async (
+  challengeId: string,
+  input: ChallengeMutationInput,
+  adminUserId: string
+): Promise<ReturnType<typeof toAdminChallengeDto>> => {
+  const challenge = await ensureChallengeById(challengeId);
+
+  if (input.key !== undefined) challenge.key = keyify(input.key);
+  if (input.slug !== undefined) challenge.slug = slugify(input.slug);
+  if (input.title !== undefined) challenge.title = cleanString(input.title);
+  if (input.summary !== undefined) challenge.summary = cleanString(input.summary);
+  if (input.description !== undefined) challenge.description = cleanString(input.description);
+  if (input.instructions !== undefined) {
+    challenge.instructions = cleanString(input.instructions) || undefined;
+  }
+  if (challengeKinds.includes(input.kind as ChallengeKind)) challenge.kind = input.kind;
+  if (challengeDifficulties.includes(input.difficulty as ChallengeDifficulty)) {
+    challenge.difficulty = input.difficulty;
+  }
+  if (input.estimatedMinutes !== undefined) {
+    challenge.estimatedMinutes = normalizeNumber(input.estimatedMinutes);
+  }
+  if (input.tags !== undefined) challenge.tags = normalizeTags(input.tags);
+  if (input.startsAt !== undefined) challenge.startsAt = parseDate(input.startsAt) || null;
+  if (input.endsAt !== undefined) challenge.endsAt = parseDate(input.endsAt) || null;
+  if (input.maxAttempts !== undefined) {
+    challenge.maxAttempts = normalizeNumber(input.maxAttempts) || undefined;
+  }
+  if (input.validation !== undefined) {
+    challenge.validation = normalizeValidation(input.validation, true) as Record<string, unknown>;
+    challenge.version += 1;
+  }
+  if (input.reward !== undefined) {
+    challenge.reward = normalizeExistingReward(challenge.reward, input.reward);
+  }
+
+  challenge.updatedBy = new Types.ObjectId(adminUserId);
+  await challenge.save();
+
+  return toAdminChallengeDto(challenge);
+};
+
+export const publishAdminChallenge = async (
+  challengeId: string,
+  adminUserId: string
+): Promise<ReturnType<typeof toAdminChallengeDto>> => {
+  const challenge = await ensureChallengeById(challengeId);
+  challenge.status = 'published';
+  challenge.publishedAt = challenge.publishedAt || new Date();
+  challenge.archivedAt = null;
+  challenge.updatedBy = new Types.ObjectId(adminUserId);
+  await challenge.save();
+  return toAdminChallengeDto(challenge);
+};
+
+export const archiveAdminChallenge = async (
+  challengeId: string,
+  adminUserId: string
+): Promise<ReturnType<typeof toAdminChallengeDto>> => {
+  const challenge = await ensureChallengeById(challengeId);
+  challenge.status = 'archived';
+  challenge.archivedAt = new Date();
+  challenge.updatedBy = new Types.ObjectId(adminUserId);
+  await challenge.save();
+  return toAdminChallengeDto(challenge);
+};
+
+export const listAdminChallengeSubmissions = async (
+  challengeId: string,
+  options: { page?: number; limit?: number } = {}
+): Promise<ListResult<ReturnType<typeof toSubmissionDto>>> => {
+  const challenge = await ensureChallengeById(challengeId);
+  const { page, limit, skip } = normalizePagination(options.page, options.limit);
+  const query = { challengeId: challenge._id };
+
+  const [items, total] = await Promise.all([
+    ChallengeSubmission.find(query).sort({ createdAt: -1 }).skip(skip).limit(limit),
+    ChallengeSubmission.countDocuments(query),
+  ]);
+
+  return {
+    items: items.map(toSubmissionDto),
+    total,
+    page,
+    limit,
+  };
+};
+
+export const listAdminChallengeProgress = async (
+  challengeId: string,
+  options: { page?: number; limit?: number; status?: ChallengeProgressStatus } = {}
+): Promise<ListResult<ReturnType<typeof toProgressDto>>> => {
+  const challenge = await ensureChallengeById(challengeId);
+  const { page, limit, skip } = normalizePagination(options.page, options.limit);
+  const query: Record<string, unknown> = { challengeId: challenge._id };
+
+  if (options.status) query.status = options.status;
+
+  const [items, total] = await Promise.all([
+    ChallengeProgress.find(query).sort({ updatedAt: -1 }).skip(skip).limit(limit),
+    ChallengeProgress.countDocuments(query),
+  ]);
+
+  return {
+    items: items.map(toProgressDto),
+    total,
+    page,
+    limit,
+  };
+};
+
+export const testAdminChallengeValidation = async (): Promise<never> => {
+  throw new ChallengeServiceError(
+    'Challenge validation engine is not implemented yet.',
+    'VALIDATOR_ERROR',
+    501
+  );
+};

--- a/backend/src/services/rewardIntegrationService.ts
+++ b/backend/src/services/rewardIntegrationService.ts
@@ -769,12 +769,25 @@ export const startPrizeversityAccountLink = async (
     { new: true, setDefaultsOnInsert: true, upsert: true }
   );
 
-  await sendPrizeversityLinkCode(
-    email,
-    code,
-    matchedAccount.matchedName || user.fullName || 'there',
-    config.classroomName || config.name
-  );
+  try {
+    await sendPrizeversityLinkCode(
+      email,
+      code,
+      matchedAccount.matchedName || user.fullName || 'there',
+      config.classroomName || config.name
+    );
+  } catch (error: unknown) {
+    await RewardIntegrationLinkVerification.deleteOne({ awsUserId: user._id });
+    log.error('failed to send prizeversity link verification code.', {
+      error: error instanceof Error ? error.message : error,
+      userId: String(user._id),
+      instanceId: config.id,
+    });
+    throw new PrizeversityError(
+      'Prizeversity match found, but AWS Student Hub could not send the verification email. Ask an admin to check SMTP credentials.',
+      503
+    );
+  }
 
   return {
     verificationRequired: true,

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -674,6 +674,10 @@ function Account({ theme: _theme }: AccountProps) {
     return null;
   }
 
+  const isPrizeversityEmailDeliveryError = prizeversityLinkError
+    .toLowerCase()
+    .includes('verification email');
+
   return (
     <div className="account-container">
       <div className="account-content">
@@ -1190,13 +1194,17 @@ function Account({ theme: _theme }: AccountProps) {
                         <strong>
                           {prizeversityVerification
                             ? 'Verification failed.'
-                            : 'No Prizeversity match found.'}
+                            : isPrizeversityEmailDeliveryError
+                              ? 'Verification email could not be sent.'
+                              : 'No Prizeversity match found.'}
                         </strong>
                         <span>{prizeversityLinkError}</span>
                         <small>
                           {prizeversityVerification
                             ? 'Check the code from your email, or resend a new code if it expired.'
-                            : 'Confirm you selected the right reward classroom and try your Prizeversity email, full name, or short ID.'}
+                            : isPrizeversityEmailDeliveryError
+                              ? 'Your account was matched, but the site email provider rejected the send. Ask an admin to check SMTP credentials.'
+                              : 'Confirm you selected the right reward classroom and try your Prizeversity email, full name, or short ID.'}
                         </small>
                       </div>
                     )}


### PR DESCRIPTION
Add provider-neutral challenge models for challenge definitions, per-user progress, and submission audit history. Challenges now have stable keys, publish/archive state, validation config, reward config, versioning, attempt limits, and safe public/admin DTO boundaries.

Add the initial challenge service layer and API surface for listing published challenges, reading challenge details, starting progress idempotently, reading user progress, and recording structured submission attempts. Admins can now create, edit, publish, archive, list, and inspect challenge progress/submissions through the new admin challenge endpoints.

Expose optional JWT auth for public challenge list/detail routes so anonymous users can browse published challenges while authenticated users receive progress context. Validation execution is intentionally stubbed with structured VALIDATOR_ERROR responses until the pluggable validator engine is implemented.