### PR TITLE
feat: add challenge validators and reward completion flow

### DIFF
--- a/backend/src/controllers/challengeAdminController.ts
+++ b/backend/src/controllers/challengeAdminController.ts
@@ -158,9 +158,23 @@ export const listProgress = async (req: Request, res: Response): Promise<void> =
   }
 };
 
-export const testValidation = async (_req: Request, res: Response): Promise<void> => {
+export const testValidation = async (req: Request, res: Response): Promise<void> => {
   try {
-    await testAdminChallengeValidation();
+    const userId =
+      typeof req.body?.userId === 'string' && req.body.userId.trim()
+        ? req.body.userId.trim()
+        : req.user?.id;
+    if (!userId) {
+      res.status(400).json({ error: 'A userId is required to test challenge validation.' });
+      return;
+    }
+
+    const result = await testAdminChallengeValidation(
+      req.params.challengeId,
+      userId,
+      req.body?.payload
+    );
+    res.json(result);
   } catch (error: unknown) {
     res.status(getErrorStatus(error, 501)).json(getErrorBody(error, 'Unable to test validation'));
   }

--- a/backend/src/controllers/challengeController.ts
+++ b/backend/src/controllers/challengeController.ts
@@ -88,7 +88,8 @@ export const submit = async (req: Request, res: Response): Promise<void> => {
       return;
     }
 
-    await submitChallenge(req.params.slug, req.user.id, req.body?.payload);
+    const result = await submitChallenge(req.params.slug, req.user.id, req.body?.payload);
+    res.json(result);
   } catch (error: unknown) {
     res.status(getErrorStatus(error, 400)).json(getErrorBody(error, 'Unable to submit challenge'));
   }

--- a/backend/src/services/challengeRewardService.ts
+++ b/backend/src/services/challengeRewardService.ts
@@ -1,0 +1,121 @@
+import { Types } from 'mongoose';
+
+import type { IChallengeDocument, IChallengeRewardConfig } from '../models/Challenge';
+import type { IChallengeProgressDocument } from '../models/ChallengeProgress';
+import RewardIntegrationEmission from '../models/RewardIntegrationEmission';
+import type { IUserDocument } from '../models/User';
+import { grantPrizeversityChallengeReward } from './rewardIntegrationService';
+
+export interface ChallengeCompletionEvent {
+  eventId: string;
+  userId: Types.ObjectId;
+  challengeId: Types.ObjectId;
+  challengeKey: string;
+  challengeTitle: string;
+  progressId: Types.ObjectId;
+  completedAt: Date;
+  reward: IChallengeRewardConfig;
+}
+
+export interface RewardGrantResult {
+  status: 'not_required' | 'sent' | 'already_sent' | 'failed';
+  emissionId?: string;
+  message?: string;
+  response?: Record<string, unknown> | null;
+}
+
+export class ChallengeRewardError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = 'ChallengeRewardError';
+    this.status = status;
+  }
+}
+
+export const buildChallengeCompletionEvent = (
+  user: IUserDocument,
+  challenge: IChallengeDocument,
+  progress: IChallengeProgressDocument
+): ChallengeCompletionEvent => {
+  const completedAt = progress.completedAt || new Date();
+  return {
+    eventId: `challenge-completed:${String(user._id)}:${challenge.key}`,
+    userId: user._id,
+    challengeId: challenge._id,
+    challengeKey: challenge.key,
+    challengeTitle: challenge.title,
+    progressId: progress._id,
+    completedAt,
+    reward: challenge.reward,
+  };
+};
+
+const getCompletionXp = (reward: IChallengeRewardConfig) => {
+  if (reward.xpMode === 'none') return { mode: 'none' as const };
+  if (reward.xpMode === 'classroom') return { mode: 'classroom' as const };
+  return {
+    mode: 'custom' as const,
+    xpAmount: reward.xpAmount || 0,
+  };
+};
+
+export const hasRewardIdentity = (user: IUserDocument): boolean => {
+  return Boolean(user.prizeversityUserId && user.prizeversityClassroomId);
+};
+
+export const grantChallengeCompletionReward = async (
+  event: ChallengeCompletionEvent,
+  user: IUserDocument
+): Promise<RewardGrantResult> => {
+  if (!event.reward?.enabled) {
+    return {
+      status: 'not_required',
+      message: 'Challenge has no reward configured.',
+    };
+  }
+
+  if (!hasRewardIdentity(user)) {
+    throw new ChallengeRewardError(
+      'Link your Prizeversity account before completing rewardable challenges.',
+      403
+    );
+  }
+
+  try {
+    const result = await grantPrizeversityChallengeReward({
+      awsUserId: event.userId,
+      prizeversityUserId: user.prizeversityUserId as string,
+      rewardIntegrationInstanceId: user.rewardIntegrationInstanceId?.toString(),
+      classroomId: user.prizeversityClassroomId,
+      challengeKey: event.challengeKey,
+      activityName: event.reward.activityName || event.challengeTitle,
+      description: event.reward.description || `Completed ${event.challengeTitle}`,
+      bits: event.reward.bits || 0,
+      stats: event.reward.stats || {},
+      completionXP: getCompletionXp(event.reward),
+      applyGroupMultipliers: event.reward.applyGroupMultipliers !== false,
+      applyPersonalMultipliers: event.reward.applyPersonalMultipliers !== false,
+    });
+
+    return {
+      status: result.alreadySent ? 'already_sent' : 'sent',
+      emissionId: result.emissionId,
+      response: result.response,
+      message: result.alreadySent ? 'Reward already sent.' : 'Reward sent.',
+    };
+  } catch (error: unknown) {
+    const emission = await RewardIntegrationEmission.findOne({
+      awsUserId: event.userId,
+      classroomId: user.prizeversityClassroomId,
+      challengeKey: event.challengeKey,
+    });
+
+    return {
+      status: 'failed',
+      emissionId: emission?._id?.toString(),
+      message: error instanceof Error ? error.message : 'Reward emission failed.',
+    };
+  }
+};

--- a/backend/src/services/challengeService.ts
+++ b/backend/src/services/challengeService.ts
@@ -14,6 +14,17 @@ import ChallengeProgress, {
 } from '../models/ChallengeProgress';
 import ChallengeSubmission from '../models/ChallengeSubmission';
 import User from '../models/User';
+import {
+  buildChallengeCompletionEvent,
+  grantChallengeCompletionReward,
+  hasRewardIdentity,
+  RewardGrantResult,
+} from './challengeRewardService';
+import {
+  ChallengeValidatorError,
+  sanitizeChallengeSubmissionPayload,
+  validateChallengeSubmission,
+} from './challengeValidatorService';
 import { getPrizeversityStatus } from './rewardIntegrationService';
 
 export type ChallengeErrorCode =
@@ -68,6 +79,14 @@ interface RewardLinkSummary {
   required: boolean;
   linked: boolean;
   configured: boolean;
+}
+
+interface ChallengeSubmitResult {
+  accepted: boolean;
+  completed: boolean;
+  message: string;
+  progress: ReturnType<typeof toProgressDto>;
+  reward?: RewardGrantResult;
 }
 
 interface ChallengeMutationInput {
@@ -415,34 +434,6 @@ const getOrCreateProgress = async (
   return progress;
 };
 
-const sanitizePayloadPreview = (payload: unknown): Record<string, unknown> => {
-  if (!isRecord(payload)) return {};
-
-  return Object.fromEntries(
-    Object.entries(payload).map(([key, value]) => {
-      const lowerKey = key.toLowerCase();
-      if (
-        lowerKey.includes('secret') ||
-        lowerKey.includes('password') ||
-        lowerKey.includes('token') ||
-        lowerKey.includes('key')
-      ) {
-        return [key, '[redacted]'];
-      }
-
-      if (typeof value === 'string') {
-        return [key, value.length > 80 ? `${value.slice(0, 80)}...` : value];
-      }
-
-      if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
-        return [key, value];
-      }
-
-      return [key, '[object]'];
-    })
-  );
-};
-
 const normalizePagination = (page?: number, limit?: number) => {
   const normalizedPage = Math.max(1, Number(page) || 1);
   const normalizedLimit = Math.min(100, Math.max(1, Number(limit) || 25));
@@ -549,14 +540,41 @@ export const submitChallenge = async (
   slug: string,
   userId: string,
   payload: unknown
-): Promise<never> => {
+): Promise<ChallengeSubmitResult> => {
   const challenge = await ensurePublishedChallenge(slug);
+  const user = await User.findById(userId);
+  if (!user) {
+    throw new ChallengeServiceError('User not found.', 'INVALID_CHALLENGE_INPUT', 404);
+  }
+
+  if (challenge.reward?.enabled && !hasRewardIdentity(user)) {
+    throw new ChallengeServiceError(
+      'Link your Prizeversity account before completing rewardable challenges.',
+      'REWARD_LINK_REQUIRED',
+      403
+    );
+  }
+
   const progress = await getOrCreateProgress(challenge, userId);
 
   if (completedStatuses.includes(progress.status)) {
-    throw new ChallengeServiceError('Challenge is already completed.', 'VALIDATION_FAILED', 409, {
+    return {
+      accepted: true,
+      completed: true,
+      message: 'Challenge is already completed.',
       progress: toProgressDto(progress),
-    });
+      reward: challenge.reward?.enabled
+        ? {
+            status:
+              progress.status === 'reward_sent'
+                ? 'already_sent'
+                : progress.status === 'reward_failed'
+                  ? 'failed'
+                  : 'not_required',
+            emissionId: progress.rewardEmissionId?.toString(),
+          }
+        : { status: 'not_required' },
+    };
   }
 
   if (challenge.maxAttempts && progress.attemptCount >= challenge.maxAttempts) {
@@ -570,7 +588,75 @@ export const submitChallenge = async (
 
   progress.attemptCount += 1;
   progress.lastSubmittedAt = new Date();
-  progress.lastValidationMessage = 'Challenge validation engine is not implemented yet.';
+
+  let validationResult;
+  try {
+    validationResult = await validateChallengeSubmission(challenge.validation, payload, {
+      user,
+      challenge,
+      progress,
+    });
+  } catch (error: unknown) {
+    const message =
+      error instanceof ChallengeValidatorError
+        ? error.message
+        : 'Challenge validation failed unexpectedly.';
+    progress.lastValidationMessage = message;
+    await progress.save();
+
+    await ChallengeSubmission.create({
+      userId: new Types.ObjectId(userId),
+      challengeId: challenge._id,
+      progressId: progress._id,
+      challengeKey: challenge.key,
+      validatorType: getValidatorType(challenge),
+      status: 'error',
+      submittedPayloadPreview: sanitizeChallengeSubmissionPayload(challenge.validation, payload),
+      validationResult: {
+        code: error instanceof ChallengeValidatorError ? 'VALIDATOR_ERROR' : 'VALIDATOR_EXCEPTION',
+      },
+      message,
+    });
+
+    throw new ChallengeServiceError(message, 'VALIDATOR_ERROR', 500, {
+      progress: toProgressDto(progress),
+    });
+  }
+
+  progress.lastValidationMessage = validationResult.message;
+
+  if (!validationResult.accepted) {
+    await progress.save();
+    await ChallengeSubmission.create({
+      userId: new Types.ObjectId(userId),
+      challengeId: challenge._id,
+      progressId: progress._id,
+      challengeKey: challenge.key,
+      validatorType: getValidatorType(challenge),
+      status: 'rejected',
+      submittedPayloadPreview: sanitizeChallengeSubmissionPayload(challenge.validation, payload),
+      validationResult: {
+        accepted: false,
+        publicDetails: validationResult.publicDetails,
+        privateDetails: validationResult.privateDetails,
+      },
+      message: validationResult.message,
+    });
+
+    return {
+      accepted: false,
+      completed: false,
+      message: validationResult.message,
+      progress: toProgressDto(progress),
+      reward: { status: 'not_required' },
+    };
+  }
+
+  const completedAt = new Date();
+  progress.status = challenge.reward?.enabled ? 'reward_pending' : 'completed';
+  progress.completedAt = progress.completedAt || completedAt;
+  progress.completionEventId =
+    progress.completionEventId || `challenge-completed:${userId}:${challenge.key}`;
   await progress.save();
 
   await ChallengeSubmission.create({
@@ -579,20 +665,38 @@ export const submitChallenge = async (
     progressId: progress._id,
     challengeKey: challenge.key,
     validatorType: getValidatorType(challenge),
-    status: 'error',
-    submittedPayloadPreview: sanitizePayloadPreview(payload),
+    status: 'accepted',
+    submittedPayloadPreview: sanitizeChallengeSubmissionPayload(challenge.validation, payload),
     validationResult: {
-      code: 'VALIDATOR_NOT_IMPLEMENTED',
+      accepted: true,
+      publicDetails: validationResult.publicDetails,
+      privateDetails: validationResult.privateDetails,
     },
-    message: 'Challenge validation engine is not implemented yet.',
+    message: validationResult.message,
   });
 
-  throw new ChallengeServiceError(
-    'Challenge validation engine is not implemented yet.',
-    'VALIDATOR_ERROR',
-    501,
-    { progress: toProgressDto(progress) }
-  );
+  const event = buildChallengeCompletionEvent(user, challenge, progress);
+  const reward = await grantChallengeCompletionReward(event, user);
+
+  if (reward.status === 'sent' || reward.status === 'already_sent') {
+    progress.status = 'reward_sent';
+    progress.rewardEmissionId = reward.emissionId ? new Types.ObjectId(reward.emissionId) : null;
+  } else if (reward.status === 'failed') {
+    progress.status = 'reward_failed';
+    progress.rewardEmissionId = reward.emissionId ? new Types.ObjectId(reward.emissionId) : null;
+  } else {
+    progress.status = 'completed';
+  }
+
+  await progress.save();
+
+  return {
+    accepted: true,
+    completed: true,
+    message: validationResult.message,
+    progress: toProgressDto(progress),
+    reward,
+  };
 };
 
 export const listAdminChallenges = async (
@@ -810,10 +914,44 @@ export const listAdminChallengeProgress = async (
   };
 };
 
-export const testAdminChallengeValidation = async (): Promise<never> => {
-  throw new ChallengeServiceError(
-    'Challenge validation engine is not implemented yet.',
-    'VALIDATOR_ERROR',
-    501
-  );
+export const testAdminChallengeValidation = async (
+  challengeId: string,
+  userId: string,
+  payload: unknown
+): Promise<{
+  accepted: boolean;
+  message: string;
+  details?: Record<string, unknown>;
+}> => {
+  const challenge = await ensureChallengeById(challengeId);
+  const user = await User.findById(userId);
+  if (!user) {
+    throw new ChallengeServiceError('User not found.', 'INVALID_CHALLENGE_INPUT', 404);
+  }
+
+  const progress =
+    (await ChallengeProgress.findOne({
+      userId: user._id,
+      challengeId: challenge._id,
+    })) ||
+    new ChallengeProgress({
+      userId: user._id,
+      challengeId: challenge._id,
+      challengeKey: challenge.key,
+      challengeVersion: challenge.version,
+      status: 'not_started',
+      attemptCount: 0,
+    });
+
+  const result = await validateChallengeSubmission(challenge.validation, payload, {
+    user,
+    challenge,
+    progress,
+  });
+
+  return {
+    accepted: result.accepted,
+    message: result.message,
+    details: result.publicDetails,
+  };
 };

--- a/backend/src/services/challengeValidatorService.ts
+++ b/backend/src/services/challengeValidatorService.ts
@@ -1,0 +1,257 @@
+import crypto from 'crypto';
+
+import type { IChallengeDocument } from '../models/Challenge';
+import type { IChallengeProgressDocument } from '../models/ChallengeProgress';
+import User, { IUserDocument } from '../models/User';
+
+export interface ChallengeValidatorContext {
+  user: IUserDocument;
+  challenge: IChallengeDocument;
+  progress: IChallengeProgressDocument;
+}
+
+export interface ChallengeValidationResult {
+  accepted: boolean;
+  message: string;
+  publicDetails?: Record<string, unknown>;
+  privateDetails?: Record<string, unknown>;
+}
+
+export interface ChallengeValidator {
+  type: string;
+  validate(
+    config: Record<string, unknown>,
+    payload: unknown,
+    context: ChallengeValidatorContext
+  ): Promise<ChallengeValidationResult>;
+  sanitizePayload?(payload: unknown): Record<string, unknown>;
+}
+
+export class ChallengeValidatorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ChallengeValidatorError';
+  }
+}
+
+interface AwsSecretValidationConfig {
+  type: 'aws_secret';
+  source?: 'user_next_challenge_password' | 'static_hash';
+  expectedValueHash?: string;
+  hashAlgorithm?: 'sha256';
+  trimSubmission?: boolean;
+  caseSensitive?: boolean;
+  acceptedPrefixes?: string[];
+}
+
+interface AwsSecretSubmissionPayload {
+  secret?: string;
+  answer?: string;
+  value?: string;
+}
+
+const validators = new Map<string, ChallengeValidator>();
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const cleanString = (value: unknown): string => {
+  return typeof value === 'string' ? value.trim() : '';
+};
+
+const normalizeStringArray = (value: unknown): string[] | undefined => {
+  if (!Array.isArray(value)) return undefined;
+  return value.map(cleanString).filter(Boolean);
+};
+
+const normalizeAwsSecretConfig = (config: Record<string, unknown>): AwsSecretValidationConfig => {
+  if (config.type !== 'aws_secret') {
+    throw new ChallengeValidatorError('Invalid AWS secret validator config type.');
+  }
+
+  const source =
+    config.source === 'static_hash' || config.source === 'user_next_challenge_password'
+      ? config.source
+      : undefined;
+  const expectedValueHash = cleanString(config.expectedValueHash) || undefined;
+
+  if (source === 'static_hash' && !expectedValueHash) {
+    throw new ChallengeValidatorError(
+      'AWS secret validator using static_hash requires expectedValueHash.'
+    );
+  }
+
+  return {
+    type: 'aws_secret',
+    source,
+    expectedValueHash,
+    hashAlgorithm: 'sha256',
+    trimSubmission: typeof config.trimSubmission === 'boolean' ? config.trimSubmission : undefined,
+    caseSensitive: typeof config.caseSensitive === 'boolean' ? config.caseSensitive : undefined,
+    acceptedPrefixes: normalizeStringArray(config.acceptedPrefixes),
+  };
+};
+
+const normalizeAwsSecretPayload = (payload: unknown): AwsSecretSubmissionPayload => {
+  if (!isRecord(payload)) return {};
+  return {
+    secret: cleanString(payload.secret) || undefined,
+    answer: cleanString(payload.answer) || undefined,
+    value: cleanString(payload.value) || undefined,
+  };
+};
+
+const normalizeSecret = (secret: string, config: AwsSecretValidationConfig): string => {
+  const trimSubmission = config.trimSubmission !== false;
+  const caseSensitive = config.caseSensitive !== false;
+  const trimmed = trimSubmission ? secret.trim() : secret;
+  return caseSensitive ? trimmed : trimmed.toLowerCase();
+};
+
+const hashSecret = (secret: string): string => {
+  return crypto.createHash('sha256').update(secret).digest('hex');
+};
+
+const extractSubmittedSecret = (
+  payload: AwsSecretSubmissionPayload,
+  config: AwsSecretValidationConfig
+): string => {
+  const rawSecret = cleanString(payload.secret || payload.answer || payload.value);
+  if (!rawSecret) return '';
+
+  const acceptedPrefixes = config.acceptedPrefixes || ['next_password='];
+  const matchingPrefix = acceptedPrefixes.find((prefix) => rawSecret.startsWith(prefix));
+
+  if (matchingPrefix) {
+    return rawSecret.slice(matchingPrefix.length);
+  }
+
+  return rawSecret;
+};
+
+const getExpectedSecret = async (
+  config: AwsSecretValidationConfig,
+  context: ChallengeValidatorContext
+): Promise<string | null> => {
+  if (config.source === 'static_hash') return null;
+
+  const userWithSecret = await User.findById(context.user._id).select('+nextChallengePassword');
+  return userWithSecret?.nextChallengePassword || null;
+};
+
+const awsSecretValidator: ChallengeValidator = {
+  type: 'aws_secret',
+
+  async validate(rawConfig, rawPayload, context) {
+    const config = normalizeAwsSecretConfig(rawConfig);
+    const payload = normalizeAwsSecretPayload(rawPayload);
+    const submittedSecret = extractSubmittedSecret(payload, config);
+    if (!submittedSecret) {
+      return {
+        accepted: false,
+        message: 'Secret value is required.',
+      };
+    }
+
+    const normalizedSubmittedSecret = normalizeSecret(submittedSecret, config);
+    const submittedHash = hashSecret(normalizedSubmittedSecret);
+
+    if (config.expectedValueHash) {
+      return {
+        accepted: submittedHash === config.expectedValueHash,
+        message:
+          submittedHash === config.expectedValueHash
+            ? 'Challenge secret accepted.'
+            : 'Challenge secret did not match.',
+        privateDetails: {
+          mode: 'static_hash',
+          hashAlgorithm: config.hashAlgorithm || 'sha256',
+        },
+      };
+    }
+
+    const expectedSecret = await getExpectedSecret(config, context);
+    if (!expectedSecret) {
+      throw new ChallengeValidatorError('No AWS challenge secret is assigned to this user.');
+    }
+
+    const normalizedExpectedSecret = normalizeSecret(expectedSecret, config);
+    const expectedHash = hashSecret(normalizedExpectedSecret);
+    const accepted = submittedHash === expectedHash;
+
+    return {
+      accepted,
+      message: accepted ? 'Challenge secret accepted.' : 'Challenge secret did not match.',
+      privateDetails: {
+        mode: 'user_next_challenge_password',
+        hashAlgorithm: 'sha256',
+      },
+    };
+  },
+
+  sanitizePayload(payload) {
+    const normalizedPayload = normalizeAwsSecretPayload(payload);
+    return {
+      submitted: Boolean(
+        normalizedPayload.secret || normalizedPayload.answer || normalizedPayload.value
+      ),
+      secret: '[redacted]',
+    };
+  },
+};
+
+export const registerChallengeValidator = (validator: ChallengeValidator): void => {
+  validators.set(validator.type, validator);
+};
+
+export const getChallengeValidator = (type: string): ChallengeValidator => {
+  const validator = validators.get(type);
+  if (!validator) {
+    throw new ChallengeValidatorError(`Unsupported challenge validator type: ${type}`);
+  }
+  return validator;
+};
+
+export const validateChallengeSubmission = async (
+  config: Record<string, unknown>,
+  payload: unknown,
+  context: ChallengeValidatorContext
+): Promise<ChallengeValidationResult> => {
+  const type = cleanString(config.type);
+  if (!type) {
+    throw new ChallengeValidatorError('Challenge validation type is missing.');
+  }
+
+  const validator = getChallengeValidator(type);
+  return validator.validate(config, payload, context);
+};
+
+export const sanitizeChallengeSubmissionPayload = (
+  config: Record<string, unknown>,
+  payload: unknown
+): Record<string, unknown> => {
+  const type = cleanString(config.type);
+  const validator = type ? validators.get(type) : null;
+  if (validator?.sanitizePayload) {
+    return validator.sanitizePayload(payload);
+  }
+
+  if (!isRecord(payload)) return {};
+  return Object.fromEntries(
+    Object.entries(payload).map(([key, value]) => {
+      const lowerKey = key.toLowerCase();
+      if (
+        lowerKey.includes('secret') ||
+        lowerKey.includes('password') ||
+        lowerKey.includes('token') ||
+        lowerKey.includes('key')
+      ) {
+        return [key, '[redacted]'];
+      }
+      return [key, typeof value === 'string' ? value.slice(0, 80) : '[provided]'];
+    })
+  );
+};
+
+registerChallengeValidator(awsSecretValidator);

--- a/backend/src/services/rewardIntegrationService.ts
+++ b/backend/src/services/rewardIntegrationService.ts
@@ -143,6 +143,7 @@ export interface PrizeversityRewardRequest {
 
 export interface PrizeversityRewardResult {
   alreadySent: boolean;
+  emissionId?: string;
   response: Record<string, unknown> | null;
 }
 
@@ -905,6 +906,7 @@ export const grantPrizeversityChallengeReward = async ({
   if (existing?.status === 'sent') {
     return {
       alreadySent: true,
+      emissionId: existing._id.toString(),
       response: (existing.responsePayload as Record<string, unknown>) || null,
     };
   }
@@ -939,6 +941,7 @@ export const grantPrizeversityChallengeReward = async ({
 
     return {
       alreadySent: false,
+      emissionId: emission._id.toString(),
       response,
     };
   } catch (error: unknown) {


### PR DESCRIPTION
Add a pluggable challenge validator registry and implement the first concrete aws_secret validator. The validator supports the existing AWS Cyber Challenge by checking submissions against the user-assigned nextChallengePassword, while also supporting static hashed answers for future challenge types.

Replace the challenge submit stub with real validation execution, sanitized submission audit records, idempotent completion handling, and structured pass/fail responses. Rejected answers now persist as rejected submissions, validator failures persist as error submissions, and accepted submissions mark challenge progress complete.

Add a provider-neutral challenge reward dispatcher that turns accepted completions into completion events and sends rewardable events through the existing reward integration layer. Prizeversity remains isolated behind the integration boundary, duplicate rewards are avoided, and failed reward emissions leave the challenge completed with reward_failed progress state.