### PR TITLE
feat: complete challenge frontend and rollout wiring

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint .",
     "rebuild-sharp-lambda": "bun install --force --os=linux --cpu=x64",
     "cleanup-aws": "tsx scripts/cleanup-aws-credentials.ts",
-    "create-superuser": "tsx scripts/createSuperuser.ts"
+    "create-superuser": "tsx scripts/createSuperuser.ts",
+    "seed-aws-cyber-challenge": "tsx scripts/seedAwsCyberChallenge.ts"
   },
   "dependencies": {
     "@aws-sdk/client-iam": "^3.1050.0",

--- a/backend/scripts/seedAwsCyberChallenge.ts
+++ b/backend/scripts/seedAwsCyberChallenge.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env bun
+
+import mongoose from 'mongoose';
+
+import env from '../src/config/env';
+import logger from '../src/config/logger';
+import Challenge from '../src/models/Challenge';
+import User from '../src/models/User';
+
+const log = logger.child({ module: 'seedAwsCyberChallenge' });
+
+const challengeKey = 'aws_cloud_security_lab';
+
+async function seedAwsCyberChallenge(): Promise<void> {
+  if (!env.MONGODB_URI) {
+    throw new Error('MONGODB_URI is required');
+  }
+
+  await mongoose.connect(env.MONGODB_URI);
+  log.info('connected to mongodb.');
+
+  const owner = await User.findOne({ role: { $in: ['superuser', 'admin'] }, status: 'active' })
+    .sort({ role: -1, createdAt: 1 })
+    .select('_id email role');
+
+  if (!owner) {
+    throw new Error('An active admin or superuser is required to seed the challenge.');
+  }
+
+  const challenge = await Challenge.findOneAndUpdate(
+    { key: challengeKey },
+    {
+      $set: {
+        key: challengeKey,
+        slug: 'aws-cloud-security-lab',
+        title: 'AWS Cloud Security Lab',
+        summary: 'Use your assigned AWS workspace to retrieve the next challenge secret.',
+        description:
+          'Configure your AWS credentials, inspect your assigned S3 secret file, and submit the secret value to complete the lab.',
+        instructions:
+          'S3 bucket: wayne-aws-club-secrets\nSecret path: secrets/{username}.txt\nExpected file format: next_password=<secret>',
+        status: 'published',
+        kind: 'single',
+        difficulty: 'medium',
+        estimatedMinutes: 20,
+        tags: ['aws', 's3', 'security'],
+        publishedAt: new Date(),
+        startsAt: null,
+        endsAt: null,
+        validation: {
+          type: 'aws_secret',
+          source: 'user_next_challenge_password',
+          acceptedPrefixes: ['next_password='],
+        },
+        reward: {
+          enabled: true,
+          bits: 50,
+          xpMode: 'custom',
+          xpAmount: 30,
+          activityName: 'AWS Cloud Security Lab',
+          description: 'Completed AWS Cloud Security Lab',
+          applyGroupMultipliers: true,
+          applyPersonalMultipliers: true,
+        },
+        updatedBy: owner._id,
+      },
+      $setOnInsert: {
+        version: 1,
+        createdBy: owner._id,
+      },
+    },
+    { new: true, upsert: true, setDefaultsOnInsert: true }
+  );
+
+  log.info(`seeded challenge ${challenge.title} (${challenge.slug}).`);
+  log.info(`owner: ${owner.email} (${owner.role}).`);
+}
+
+seedAwsCyberChallenge()
+  .catch((error: unknown) => {
+    log.error('failed to seed aws cyber challenge.', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await mongoose.disconnect();
+    log.info('disconnected from mongodb.');
+  });

--- a/backend/src/controllers/challengeAdminController.ts
+++ b/backend/src/controllers/challengeAdminController.ts
@@ -4,6 +4,7 @@ import {
   ChallengeServiceError,
   archiveAdminChallenge,
   createAdminChallenge,
+  deleteAdminChallenge,
   getAdminChallenge,
   listAdminChallengeProgress,
   listAdminChallengeSubmissions,
@@ -12,8 +13,31 @@ import {
   testAdminChallengeValidation,
   updateAdminChallenge,
 } from '../services/challengeService';
+import type { ChallengeStatus } from '../models/Challenge';
+import type { ChallengeProgressStatus } from '../models/ChallengeProgress';
 
 const getAdminUserId = (req: Request): string | null => req.user?.id || null;
+const challengeStatuses: ChallengeStatus[] = ['draft', 'published', 'archived'];
+const progressStatuses: ChallengeProgressStatus[] = [
+  'not_started',
+  'in_progress',
+  'completed',
+  'reward_pending',
+  'reward_sent',
+  'reward_failed',
+];
+
+const parseChallengeStatus = (value: unknown): ChallengeStatus | undefined => {
+  return typeof value === 'string' && challengeStatuses.includes(value as ChallengeStatus)
+    ? (value as ChallengeStatus)
+    : undefined;
+};
+
+const parseProgressStatus = (value: unknown): ChallengeProgressStatus | undefined => {
+  return typeof value === 'string' && progressStatuses.includes(value as ChallengeProgressStatus)
+    ? (value as ChallengeProgressStatus)
+    : undefined;
+};
 
 const getErrorBody = (error: unknown, fallback: string) => {
   if (error instanceof ChallengeServiceError) {
@@ -37,7 +61,7 @@ const getErrorStatus = (error: unknown, fallback = 500): number => {
 export const listChallenges = async (req: Request, res: Response): Promise<void> => {
   try {
     const result = await listAdminChallenges({
-      status: typeof req.query.status === 'string' ? (req.query.status as any) : undefined,
+      status: parseChallengeStatus(req.query.status),
       search: typeof req.query.search === 'string' ? req.query.search : undefined,
       page: Number(req.query.page),
       limit: Number(req.query.limit),
@@ -133,6 +157,18 @@ export const archiveChallenge = async (req: Request, res: Response): Promise<voi
   }
 };
 
+export const deleteChallenge = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const result = await deleteAdminChallenge(req.params.challengeId);
+    res.json({
+      message: 'Challenge deleted',
+      ...result,
+    });
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error, 400)).json(getErrorBody(error, 'Unable to delete challenge'));
+  }
+};
+
 export const listSubmissions = async (req: Request, res: Response): Promise<void> => {
   try {
     const result = await listAdminChallengeSubmissions(req.params.challengeId, {
@@ -150,7 +186,7 @@ export const listProgress = async (req: Request, res: Response): Promise<void> =
     const result = await listAdminChallengeProgress(req.params.challengeId, {
       page: Number(req.query.page),
       limit: Number(req.query.limit),
-      status: typeof req.query.status === 'string' ? (req.query.status as any) : undefined,
+      status: parseProgressStatus(req.query.status),
     });
     res.json(result);
   } catch (error: unknown) {

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -22,6 +22,7 @@ router.get('/challenges', requireAdmin, challengeAdminController.listChallenges)
 router.post('/challenges', requireAdmin, challengeAdminController.createChallenge);
 router.get('/challenges/:challengeId', requireAdmin, challengeAdminController.getChallenge);
 router.patch('/challenges/:challengeId', requireAdmin, challengeAdminController.updateChallenge);
+router.delete('/challenges/:challengeId', requireAdmin, challengeAdminController.deleteChallenge);
 router.post(
   '/challenges/:challengeId/publish',
   requireAdmin,

--- a/backend/src/services/challengeService.ts
+++ b/backend/src/services/challengeService.ts
@@ -12,7 +12,7 @@ import ChallengeProgress, {
   ChallengeProgressStatus,
   IChallengeProgressDocument,
 } from '../models/ChallengeProgress';
-import ChallengeSubmission from '../models/ChallengeSubmission';
+import ChallengeSubmission, { IChallengeSubmissionDocument } from '../models/ChallengeSubmission';
 import User from '../models/User';
 import {
   buildChallengeCompletionEvent,
@@ -34,6 +34,7 @@ export type ChallengeErrorCode =
   | 'MAX_ATTEMPTS_REACHED'
   | 'VALIDATION_FAILED'
   | 'VALIDATOR_ERROR'
+  | 'CHALLENGE_DELETE_BLOCKED'
   | 'INVALID_CHALLENGE_INPUT';
 
 export class ChallengeServiceError extends Error {
@@ -346,7 +347,7 @@ const toAdminChallengeDto = (challenge: IChallengeDocument) => ({
   updatedAt: challenge.updatedAt,
 });
 
-const toSubmissionDto = (submission: any) => ({
+const toSubmissionDto = (submission: IChallengeSubmissionDocument) => ({
   id: String(submission._id),
   userId: submission.userId?.toString(),
   challengeId: submission.challengeId?.toString(),
@@ -868,6 +869,40 @@ export const archiveAdminChallenge = async (
   challenge.updatedBy = new Types.ObjectId(adminUserId);
   await challenge.save();
   return toAdminChallengeDto(challenge);
+};
+
+export const deleteAdminChallenge = async (
+  challengeId: string
+): Promise<{
+  deleted: true;
+  challengeId: string;
+  progressDeleted: number;
+  submissionsDeleted: number;
+}> => {
+  const challenge = await ensureChallengeById(challengeId);
+
+  if (challenge.status === 'published') {
+    throw new ChallengeServiceError(
+      'Archive the challenge before deleting it.',
+      'CHALLENGE_DELETE_BLOCKED',
+      409,
+      { status: challenge.status }
+    );
+  }
+
+  const [submissionResult, progressResult] = await Promise.all([
+    ChallengeSubmission.deleteMany({ challengeId: challenge._id }),
+    ChallengeProgress.deleteMany({ challengeId: challenge._id }),
+  ]);
+
+  await Challenge.deleteOne({ _id: challenge._id });
+
+  return {
+    deleted: true,
+    challengeId: String(challenge._id),
+    progressDeleted: progressResult.deletedCount || 0,
+    submissionsDeleted: submissionResult.deletedCount || 0,
+  };
 };
 
 export const listAdminChallengeSubmissions = async (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import About from './pages/About';
 import Resources from './pages/Resources';
 import Events from './pages/Events';
 import Challenges from './pages/Challenges';
+import ChallengeDetail from './pages/ChallengeDetail';
 import Auth from './pages/Auth';
 import Account from './pages/Account';
 import PublicProfile from './pages/PublicProfile';
@@ -39,6 +40,7 @@ function AppContent() {
           <Route path="/resources" element={<Resources />} />
           <Route path="/events" element={<Events theme={theme} />} />
           <Route path="/challenges" element={<Challenges theme={theme} />} />
+          <Route path="/challenges/:slug" element={<ChallengeDetail theme={theme} />} />
           <Route path="/auth" element={<Auth theme={theme} />} />
           <Route path="/setup" element={<QuickSetup theme={theme} />} />
           <Route path="/account" element={<Account theme={theme} />} />

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -1302,6 +1302,14 @@ function Account({ theme: _theme }: AccountProps) {
                       >
                         <Lock size={16} aria-hidden="true" /> Reveal credentials
                       </motion.button>
+                      <motion.button
+                        className="show-modal-btn"
+                        onClick={() => navigate('/challenges/aws-cloud-security-lab')}
+                        whileHover={{ y: -2 }}
+                        whileTap={{ scale: 0.98 }}
+                      >
+                        <Target size={16} aria-hidden="true" /> Open challenge page
+                      </motion.button>
                     </div>
                   ) : (
                     <div className="credentials-display">
@@ -1354,6 +1362,14 @@ function Account({ theme: _theme }: AccountProps) {
                           whileTap={{ scale: 0.98 }}
                         >
                           <Target size={16} aria-hidden="true" /> Open instructions
+                        </motion.button>
+                        <motion.button
+                          className="show-modal-btn"
+                          onClick={() => navigate('/challenges/aws-cloud-security-lab')}
+                          whileHover={{ y: -2 }}
+                          whileTap={{ scale: 0.98 }}
+                        >
+                          <Target size={16} aria-hidden="true" /> Open challenge page
                         </motion.button>
                       </div>
                     </div>

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -237,6 +237,7 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
   const [challengeSaving, setChallengeSaving] = useState<boolean>(false);
   const [challengeStatusFilter, setChallengeStatusFilter] = useState<ChallengeStatus | ''>('');
   const [updatingChallengeId, setUpdatingChallengeId] = useState<string | null>(null);
+  const [challengeToDelete, setChallengeToDelete] = useState<AdminChallenge | null>(null);
 
   const navigate = useNavigate();
   const { user, loading: authLoading } = useAuth();
@@ -563,6 +564,34 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
       loadAdminChallenges();
     } catch (err) {
       showToast(getErrorMessage(err, 'Failed to archive challenge'), 'error');
+    } finally {
+      setUpdatingChallengeId(null);
+    }
+  };
+
+  const handleDeleteChallenge = (challenge: AdminChallenge) => {
+    if (challenge.status === 'published') {
+      showToast('Archive the challenge before deleting it', 'error');
+      return;
+    }
+
+    setChallengeToDelete(challenge);
+  };
+
+  const handleConfirmDeleteChallenge = async () => {
+    if (!challengeToDelete) return;
+
+    setUpdatingChallengeId(challengeToDelete.id);
+    try {
+      const response = await adminAPI.deleteChallenge(challengeToDelete.id);
+      showToast(
+        `Challenge deleted. Removed ${response.progressDeleted} progress records and ${response.submissionsDeleted} submissions.`,
+        'success'
+      );
+      setChallengeToDelete(null);
+      loadAdminChallenges();
+    } catch (err) {
+      showToast(getErrorMessage(err, 'Failed to delete challenge'), 'error');
     } finally {
       setUpdatingChallengeId(null);
     }
@@ -1222,6 +1251,22 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
                               Archive
                             </button>
                           )}
+                          <button
+                            type="button"
+                            className="action-btn delete-btn"
+                            onClick={() => handleDeleteChallenge(challenge)}
+                            disabled={
+                              updatingChallengeId === challenge.id ||
+                              challenge.status === 'published'
+                            }
+                            title={
+                              challenge.status === 'published'
+                                ? 'Archive this challenge before deleting it.'
+                                : 'Delete this challenge and its related records.'
+                            }
+                          >
+                            Delete
+                          </button>
                         </div>
                       </article>
                     ))}
@@ -1621,6 +1666,67 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
               </button>
               <button onClick={handleDeleteUser} className="delete-btn">
                 Delete User
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {challengeToDelete && (
+        <div
+          className="modal-overlay"
+          onClick={() => {
+            if (updatingChallengeId !== challengeToDelete.id) {
+              setChallengeToDelete(null);
+            }
+          }}
+        >
+          <div
+            className="modal-content challenge-delete-modal"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <span className="modal-eyebrow">Delete challenge</span>
+            <h3>{challengeToDelete.title}</h3>
+            <p>
+              This will permanently remove the challenge record and all related progress and
+              submissions.
+            </p>
+
+            <div className="challenge-delete-summary">
+              <div>
+                <span>Status</span>
+                <strong>{challengeToDelete.status}</strong>
+              </div>
+              <div>
+                <span>Slug</span>
+                <strong>{challengeToDelete.slug}</strong>
+              </div>
+              <div>
+                <span>Reward</span>
+                <strong>
+                  {challengeToDelete.reward.enabled
+                    ? `${challengeToDelete.reward.bits} bits`
+                    : 'Off'}
+                </strong>
+              </div>
+            </div>
+
+            <p className="warning-text">This action cannot be undone.</p>
+
+            <div className="modal-actions">
+              <button
+                onClick={() => setChallengeToDelete(null)}
+                className="cancel-btn"
+                disabled={updatingChallengeId === challengeToDelete.id}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirmDeleteChallenge}
+                className="delete-btn"
+                disabled={updatingChallengeId === challengeToDelete.id}
+              >
+                {updatingChallengeId === challengeToDelete.id ? 'Deleting...' : 'Delete Challenge'}
               </button>
             </div>
           </div>

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -7,6 +7,13 @@ import { adminAPI } from '../utils/api';
 import './styles/AdminDashboard.css';
 import type { AdminStats, AdminUser, EmailQueueEntry } from '../types/admin';
 import type {
+  AdminChallenge,
+  AdminChallengePayload,
+  ChallengeDifficulty,
+  ChallengeKind,
+  ChallengeStatus,
+} from '../types/challenge';
+import type {
   RewardIntegrationInstance,
   RewardIntegrationInstancePayload,
 } from '../types/rewardIntegration';
@@ -21,7 +28,7 @@ interface IconProps {
   className?: string;
 }
 
-type AdminTab = 'dashboard' | 'users' | 'queue' | 'rewards';
+type AdminTab = 'dashboard' | 'users' | 'queue' | 'rewards' | 'challenges';
 type RoleFilter = UserRole | '';
 type StatusFilter = UserStatus | '';
 type QueueStats = Record<string, any>;
@@ -34,6 +41,24 @@ interface RewardIntegrationFormData {
   classroomId: string;
   classroomName: string;
   scopes: string;
+}
+
+interface ChallengeFormData {
+  key: string;
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  instructions: string;
+  kind: ChallengeKind;
+  difficulty: ChallengeDifficulty;
+  estimatedMinutes: string;
+  tags: string;
+  maxAttempts: string;
+  validationJson: string;
+  rewardEnabled: boolean;
+  rewardBits: string;
+  rewardXpAmount: string;
 }
 
 interface DashboardStats extends AdminStats {
@@ -64,6 +89,34 @@ const emptyRewardForm: RewardIntegrationFormData = {
   classroomId: '',
   classroomName: '',
   scopes: defaultRewardScopes,
+};
+
+const emptyChallengeForm: ChallengeFormData = {
+  key: 'aws_cloud_security_lab',
+  slug: 'aws-cloud-security-lab',
+  title: 'AWS Cloud Security Lab',
+  summary: 'Use your assigned AWS workspace to retrieve the next challenge secret.',
+  description:
+    'Configure your AWS credentials, inspect your assigned S3 secret file, and submit the secret value to complete the lab.',
+  instructions:
+    'S3 bucket: wayne-aws-club-secrets\nSecret path: secrets/{username}.txt\nExpected file format: next_password=<secret>',
+  kind: 'single',
+  difficulty: 'medium',
+  estimatedMinutes: '20',
+  tags: 'aws,s3,security',
+  maxAttempts: '',
+  validationJson: JSON.stringify(
+    {
+      type: 'aws_secret',
+      source: 'user_next_challenge_password',
+      acceptedPrefixes: ['next_password='],
+    },
+    null,
+    2
+  ),
+  rewardEnabled: true,
+  rewardBits: '50',
+  rewardXpAmount: '30',
 };
 
 const getErrorMessage = (err: unknown, fallback: string): string =>
@@ -176,6 +229,14 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
   const [rewardLoading, setRewardLoading] = useState<boolean>(false);
   const [rewardSaving, setRewardSaving] = useState<boolean>(false);
   const [testingRewardId, setTestingRewardId] = useState<string | null>(null);
+
+  // Challenge admin state
+  const [adminChallenges, setAdminChallenges] = useState<AdminChallenge[]>([]);
+  const [challengeForm, setChallengeForm] = useState<ChallengeFormData>(emptyChallengeForm);
+  const [challengeLoading, setChallengeLoading] = useState<boolean>(false);
+  const [challengeSaving, setChallengeSaving] = useState<boolean>(false);
+  const [challengeStatusFilter, setChallengeStatusFilter] = useState<ChallengeStatus | ''>('');
+  const [updatingChallengeId, setUpdatingChallengeId] = useState<string | null>(null);
 
   const navigate = useNavigate();
   const { user, loading: authLoading } = useAuth();
@@ -296,6 +357,25 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
     }
   }, [activeTab, loadRewardIntegrations]);
 
+  const loadAdminChallenges = useCallback(async () => {
+    setChallengeLoading(true);
+    try {
+      const response = await adminAPI.listChallenges(challengeStatusFilter || undefined);
+      setAdminChallenges(response.items || []);
+      setError('');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to load challenges'));
+    } finally {
+      setChallengeLoading(false);
+    }
+  }, [challengeStatusFilter]);
+
+  useEffect(() => {
+    if (activeTab === 'challenges') {
+      loadAdminChallenges();
+    }
+  }, [activeTab, loadAdminChallenges]);
+
   const handleRetryEmail = async (queueId: string) => {
     if (!queueId) {
       showToast('Unable to retry email: missing queue ID', 'error');
@@ -397,6 +477,94 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
       loadRewardIntegrations();
     } catch (err) {
       showToast(getErrorMessage(err, 'Failed to update reward integration'), 'error');
+    }
+  };
+
+  const handleChallengeFieldChange = <K extends keyof ChallengeFormData>(
+    field: K,
+    value: ChallengeFormData[K]
+  ) => {
+    setChallengeForm((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const buildChallengePayload = (): AdminChallengePayload => {
+    const validation = JSON.parse(challengeForm.validationJson) as Record<string, unknown>;
+    return {
+      key: challengeForm.key.trim(),
+      slug: challengeForm.slug.trim(),
+      title: challengeForm.title.trim(),
+      summary: challengeForm.summary.trim(),
+      description: challengeForm.description.trim(),
+      instructions: challengeForm.instructions.trim(),
+      kind: challengeForm.kind,
+      difficulty: challengeForm.difficulty,
+      estimatedMinutes: Number(challengeForm.estimatedMinutes) || undefined,
+      tags: challengeForm.tags
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter(Boolean),
+      maxAttempts: Number(challengeForm.maxAttempts) || undefined,
+      validation,
+      reward: {
+        enabled: challengeForm.rewardEnabled,
+        bits: Number(challengeForm.rewardBits) || 0,
+        xpMode: challengeForm.rewardXpAmount ? 'custom' : 'none',
+        xpAmount: Number(challengeForm.rewardXpAmount) || undefined,
+        activityName: challengeForm.title.trim(),
+        description: `Completed ${challengeForm.title.trim()}`,
+      },
+    };
+  };
+
+  const handleCreateChallenge = async () => {
+    if (
+      !challengeForm.title.trim() ||
+      !challengeForm.summary.trim() ||
+      !challengeForm.description.trim()
+    ) {
+      showToast('Title, summary, and description are required', 'error');
+      return;
+    }
+
+    setChallengeSaving(true);
+    try {
+      await adminAPI.createChallenge(buildChallengePayload());
+      showToast('Challenge created', 'success');
+      setChallengeForm(emptyChallengeForm);
+      loadAdminChallenges();
+    } catch (err) {
+      showToast(getErrorMessage(err, 'Failed to create challenge'), 'error');
+    } finally {
+      setChallengeSaving(false);
+    }
+  };
+
+  const handlePublishChallenge = async (challengeId: string) => {
+    setUpdatingChallengeId(challengeId);
+    try {
+      await adminAPI.publishChallenge(challengeId);
+      showToast('Challenge published', 'success');
+      loadAdminChallenges();
+    } catch (err) {
+      showToast(getErrorMessage(err, 'Failed to publish challenge'), 'error');
+    } finally {
+      setUpdatingChallengeId(null);
+    }
+  };
+
+  const handleArchiveChallenge = async (challengeId: string) => {
+    setUpdatingChallengeId(challengeId);
+    try {
+      await adminAPI.archiveChallenge(challengeId);
+      showToast('Challenge archived', 'success');
+      loadAdminChallenges();
+    } catch (err) {
+      showToast(getErrorMessage(err, 'Failed to archive challenge'), 'error');
+    } finally {
+      setUpdatingChallengeId(null);
     }
   };
 
@@ -507,6 +675,16 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
             <AccountIcon className="tab-icon" />
             User Management
           </button>
+          {(user?.role === 'admin' || user?.role === 'superuser') && (
+            <button
+              className={`tab-button ${activeTab === 'challenges' ? 'active' : ''}`}
+              data-tab="challenges"
+              onClick={() => setActiveTab('challenges')}
+            >
+              <CheckIcon className="tab-icon" />
+              Challenges
+            </button>
+          )}
           {(user?.role === 'admin' || user?.role === 'superuser') && (
             <button
               className={`tab-button ${activeTab === 'rewards' ? 'active' : ''}`}
@@ -767,6 +945,290 @@ function AdminDashboard({ theme }: AdminDashboardProps) {
                 )}
               </>
             )}
+          </motion.div>
+        )}
+
+        {activeTab === 'challenges' && (
+          <motion.div
+            className="challenges-admin-content"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            <div className="reward-admin-grid">
+              <section className="reward-admin-panel">
+                <div className="reward-admin-heading">
+                  <span>Authoring</span>
+                  <h2>Create challenge</h2>
+                  <p>
+                    Create provider-neutral challenges. The default config migrates the existing AWS
+                    Cyber Challenge into the new validator/reward flow.
+                  </p>
+                </div>
+
+                <div className="reward-form">
+                  <label>
+                    Title
+                    <input
+                      type="text"
+                      value={challengeForm.title}
+                      onChange={(e) => handleChallengeFieldChange('title', e.target.value)}
+                    />
+                  </label>
+
+                  <div className="challenge-admin-two-col">
+                    <label>
+                      Key
+                      <input
+                        type="text"
+                        value={challengeForm.key}
+                        onChange={(e) => handleChallengeFieldChange('key', e.target.value)}
+                      />
+                    </label>
+                    <label>
+                      Slug
+                      <input
+                        type="text"
+                        value={challengeForm.slug}
+                        onChange={(e) => handleChallengeFieldChange('slug', e.target.value)}
+                      />
+                    </label>
+                  </div>
+
+                  <label>
+                    Summary
+                    <input
+                      type="text"
+                      value={challengeForm.summary}
+                      onChange={(e) => handleChallengeFieldChange('summary', e.target.value)}
+                    />
+                  </label>
+
+                  <label>
+                    Description
+                    <textarea
+                      value={challengeForm.description}
+                      onChange={(e) => handleChallengeFieldChange('description', e.target.value)}
+                    />
+                  </label>
+
+                  <label>
+                    Instructions
+                    <textarea
+                      value={challengeForm.instructions}
+                      onChange={(e) => handleChallengeFieldChange('instructions', e.target.value)}
+                    />
+                  </label>
+
+                  <div className="challenge-admin-two-col">
+                    <label>
+                      Kind
+                      <select
+                        value={challengeForm.kind}
+                        onChange={(e) =>
+                          handleChallengeFieldChange('kind', e.target.value as ChallengeKind)
+                        }
+                      >
+                        <option value="single">Single goal</option>
+                        <option value="multi_part">Multi-part</option>
+                      </select>
+                    </label>
+                    <label>
+                      Difficulty
+                      <select
+                        value={challengeForm.difficulty}
+                        onChange={(e) =>
+                          handleChallengeFieldChange(
+                            'difficulty',
+                            e.target.value as ChallengeDifficulty
+                          )
+                        }
+                      >
+                        <option value="easy">Easy</option>
+                        <option value="medium">Medium</option>
+                        <option value="hard">Hard</option>
+                        <option value="expert">Expert</option>
+                      </select>
+                    </label>
+                  </div>
+
+                  <div className="challenge-admin-two-col">
+                    <label>
+                      Estimated minutes
+                      <input
+                        type="number"
+                        min="1"
+                        value={challengeForm.estimatedMinutes}
+                        onChange={(e) =>
+                          handleChallengeFieldChange('estimatedMinutes', e.target.value)
+                        }
+                      />
+                    </label>
+                    <label>
+                      Max attempts
+                      <input
+                        type="number"
+                        min="1"
+                        value={challengeForm.maxAttempts}
+                        onChange={(e) => handleChallengeFieldChange('maxAttempts', e.target.value)}
+                        placeholder="Unlimited"
+                      />
+                    </label>
+                  </div>
+
+                  <label>
+                    Tags
+                    <input
+                      type="text"
+                      value={challengeForm.tags}
+                      onChange={(e) => handleChallengeFieldChange('tags', e.target.value)}
+                      placeholder="aws,s3,security"
+                    />
+                  </label>
+
+                  <label>
+                    Validation JSON
+                    <textarea
+                      value={challengeForm.validationJson}
+                      onChange={(e) => handleChallengeFieldChange('validationJson', e.target.value)}
+                    />
+                  </label>
+
+                  <div className="challenge-admin-two-col">
+                    <label>
+                      Reward bits
+                      <input
+                        type="number"
+                        min="0"
+                        value={challengeForm.rewardBits}
+                        onChange={(e) => handleChallengeFieldChange('rewardBits', e.target.value)}
+                      />
+                    </label>
+                    <label>
+                      Reward XP
+                      <input
+                        type="number"
+                        min="0"
+                        value={challengeForm.rewardXpAmount}
+                        onChange={(e) =>
+                          handleChallengeFieldChange('rewardXpAmount', e.target.value)
+                        }
+                      />
+                    </label>
+                  </div>
+
+                  <label className="challenge-admin-checkbox">
+                    <input
+                      type="checkbox"
+                      checked={challengeForm.rewardEnabled}
+                      onChange={(e) =>
+                        handleChallengeFieldChange('rewardEnabled', e.target.checked)
+                      }
+                    />
+                    Reward enabled
+                  </label>
+
+                  <button
+                    type="button"
+                    className="create-reward-instance-btn"
+                    onClick={handleCreateChallenge}
+                    disabled={challengeSaving}
+                  >
+                    {challengeSaving ? 'Creating...' : 'Create challenge'}
+                  </button>
+                </div>
+              </section>
+
+              <section className="reward-admin-panel">
+                <div className="reward-admin-heading">
+                  <span>Catalog</span>
+                  <h2>Challenge records</h2>
+                  <p>Publish, archive, and inspect the current challenge catalog.</p>
+                </div>
+
+                <div className="challenge-admin-actions">
+                  <select
+                    value={challengeStatusFilter}
+                    onChange={(e) =>
+                      setChallengeStatusFilter(e.target.value as ChallengeStatus | '')
+                    }
+                  >
+                    <option value="">All statuses</option>
+                    <option value="draft">Draft</option>
+                    <option value="published">Published</option>
+                    <option value="archived">Archived</option>
+                  </select>
+                  <button type="button" onClick={loadAdminChallenges}>
+                    Refresh
+                  </button>
+                </div>
+
+                {challengeLoading ? (
+                  <div className="loading-users">Loading challenges...</div>
+                ) : adminChallenges.length === 0 ? (
+                  <div className="empty-reward-instances">No challenges created yet.</div>
+                ) : (
+                  <div className="reward-instance-list">
+                    {adminChallenges.map((challenge) => (
+                      <article key={challenge.id} className="reward-instance-card">
+                        <div className="reward-instance-topline">
+                          <span data-active={challenge.status === 'published'}>
+                            {challenge.status}
+                          </span>
+                          <span>{challenge.validation?.type as string}</span>
+                        </div>
+                        <h3>{challenge.title}</h3>
+                        <p>{challenge.summary}</p>
+
+                        <div className="reward-instance-meta">
+                          <div>
+                            <span>Slug</span>
+                            <strong>{challenge.slug}</strong>
+                          </div>
+                          <div>
+                            <span>Difficulty</span>
+                            <strong>{challenge.difficulty}</strong>
+                          </div>
+                          <div>
+                            <span>Reward</span>
+                            <strong>
+                              {challenge.reward.enabled ? `${challenge.reward.bits} bits` : 'Off'}
+                            </strong>
+                          </div>
+                          <div>
+                            <span>Attempts</span>
+                            <strong>{challenge.maxAttempts || 'Unlimited'}</strong>
+                          </div>
+                        </div>
+
+                        <div className="reward-instance-actions">
+                          {challenge.status !== 'published' && (
+                            <button
+                              type="button"
+                              className="action-btn role-btn"
+                              onClick={() => handlePublishChallenge(challenge.id)}
+                              disabled={updatingChallengeId === challenge.id}
+                            >
+                              Publish
+                            </button>
+                          )}
+                          {challenge.status !== 'archived' && (
+                            <button
+                              type="button"
+                              className="action-btn ban-btn"
+                              onClick={() => handleArchiveChallenge(challenge.id)}
+                              disabled={updatingChallengeId === challenge.id}
+                            >
+                              Archive
+                            </button>
+                          )}
+                        </div>
+                      </article>
+                    ))}
+                  </div>
+                )}
+              </section>
+            </div>
           </motion.div>
         )}
 

--- a/frontend/src/pages/ChallengeDetail.tsx
+++ b/frontend/src/pages/ChallengeDetail.tsx
@@ -1,0 +1,347 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { motion } from 'motion/react';
+import { ArrowLeft, CheckCircle2, Link2, Lock, Send, ShieldCheck, Trophy } from 'lucide-react';
+
+import { useAuth } from '../context/AuthContext';
+import { challengeAPI } from '../utils/api';
+import type {
+  ChallengeDetail as ChallengeDetailType,
+  ChallengeProgress,
+  ChallengeRewardLinkSummary,
+  ChallengeSubmitResponse,
+} from '../types/challenge';
+import type { ThemeProps } from '../types';
+import type { CSSProperties } from 'react';
+import './styles/Challenges.css';
+
+const completedStatuses = new Set(['completed', 'reward_pending', 'reward_sent', 'reward_failed']);
+type RewardBurstStyle = CSSProperties & { '--burst-index': number };
+
+const getStatusCopy = (progress?: ChallengeProgress | null): string => {
+  if (!progress || progress.status === 'not_started') return 'Not started';
+  if (progress.status === 'in_progress') return 'In progress';
+  if (progress.status === 'reward_pending') return 'Reward pending';
+  if (progress.status === 'reward_sent') return 'Completed and rewarded';
+  if (progress.status === 'reward_failed') return 'Completed, reward failed';
+  return 'Completed';
+};
+
+const getRewardSummary = (challenge: ChallengeDetailType): string => {
+  if (!challenge.reward.enabled) return 'No reward configured';
+  const rewards = [`${challenge.reward.bits} bits`];
+  if (challenge.reward.xpAmount && challenge.reward.xpAmount > 0) {
+    rewards.push(`${challenge.reward.xpAmount} XP`);
+  }
+  return rewards.join(' + ');
+};
+
+const getRewardStatusCopy = (
+  responseReward?: ChallengeSubmitResponse['reward'],
+  progress?: ChallengeProgress | null
+): string => {
+  const status = responseReward?.status || progress?.status;
+  if (status === 'sent' || status === 'already_sent' || status === 'reward_sent') {
+    return 'Reward synced successfully.';
+  }
+  if (status === 'failed' || status === 'reward_failed') {
+    return 'Challenge completed, but reward sync needs attention.';
+  }
+  if (status === 'not_required' || status === 'completed') {
+    return 'Challenge completed.';
+  }
+  return 'Reward sync pending.';
+};
+
+function ChallengeDetail({ theme: _theme }: ThemeProps) {
+  const { slug = '' } = useParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [challenge, setChallenge] = useState<ChallengeDetailType | null>(null);
+  const [progress, setProgress] = useState<ChallengeProgress | null>(null);
+  const [rewardLink, setRewardLink] = useState<ChallengeRewardLinkSummary | null>(null);
+  const [secret, setSecret] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [starting, setStarting] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [rewardModalOpen, setRewardModalOpen] = useState(false);
+  const [lastSubmitReward, setLastSubmitReward] = useState<ChallengeSubmitResponse['reward']>();
+
+  useEffect(() => {
+    let shouldUpdate = true;
+    setLoading(true);
+    setError('');
+
+    challengeAPI
+      .get(slug)
+      .then((response) => {
+        if (!shouldUpdate) return;
+        setChallenge(response.challenge);
+        setProgress(response.challenge.progress || null);
+        setRewardLink(response.rewardLink);
+      })
+      .catch((err) => {
+        if (shouldUpdate) {
+          setError(err instanceof Error ? err.message : 'Failed to load challenge');
+        }
+      })
+      .finally(() => {
+        if (shouldUpdate) setLoading(false);
+      });
+
+    return () => {
+      shouldUpdate = false;
+    };
+  }, [slug]);
+
+  const isCompleted = completedStatuses.has(progress?.status || '');
+  const rewardLocked = Boolean(
+    user && challenge?.reward.enabled && rewardLink && !rewardLink.linked
+  );
+  const handleStart = async () => {
+    if (!user) {
+      navigate(`/auth?redirect=/challenges/${slug}`);
+      return;
+    }
+
+    setStarting(true);
+    setError('');
+    setSuccess('');
+
+    try {
+      const response = await challengeAPI.start(slug);
+      setChallenge(response.challenge);
+      setProgress(response.progress);
+      setSuccess('Challenge started.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start challenge');
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!secret.trim()) {
+      setError('Enter the challenge secret before submitting.');
+      return;
+    }
+
+    setSubmitting(true);
+    setError('');
+    setSuccess('');
+
+    try {
+      const response = await challengeAPI.submit(slug, { secret });
+      setProgress(response.progress);
+      setSuccess(response.message);
+      if (response.accepted && response.completed) {
+        setSecret('');
+        setLastSubmitReward(response.reward);
+        setRewardModalOpen(true);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to submit challenge');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="landing-container">
+        <section className="challenge-detail-section">
+          <div className="challenges-loading">Loading challenge...</div>
+        </section>
+      </div>
+    );
+  }
+
+  if (!challenge) {
+    return (
+      <div className="landing-container">
+        <section className="challenge-detail-section">
+          <Link to="/challenges" className="challenge-back-link">
+            <ArrowLeft size={16} /> Back to Challenges
+          </Link>
+          <div className="challenges-empty">{error || 'Challenge not found.'}</div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="landing-container">
+      <section className="challenge-detail-section">
+        <Link to="/challenges" className="challenge-back-link">
+          <ArrowLeft size={16} /> Back to Challenges
+        </Link>
+
+        <motion.div
+          className="challenge-detail-hero"
+          initial={{ opacity: 0, y: 18 }}
+          animate={{ opacity: 1, y: 0 }}
+        >
+          <div>
+            <span className="challenge-detail-eyebrow">{challenge.difficulty}</span>
+            <h1>{challenge.title}</h1>
+            <p>{challenge.summary}</p>
+          </div>
+          <div className="challenge-detail-status">
+            <ShieldCheck size={24} aria-hidden="true" />
+            <span>{getStatusCopy(progress)}</span>
+          </div>
+        </motion.div>
+
+        {error && <div className="challenge-error-banner">{error}</div>}
+        {success && <div className="challenge-success-banner">{success}</div>}
+
+        {rewardLocked && (
+          <div className="challenge-detail-gate">
+            <Link2 size={22} aria-hidden="true" />
+            <div>
+              <strong>Prizeversity link required</strong>
+              <span>
+                This challenge is rewardable. Link your Prizeversity classroom account before
+                submitting completion.
+              </span>
+            </div>
+            <button type="button" onClick={() => navigate('/account#prizeversity-rewards')}>
+              Link account
+            </button>
+          </div>
+        )}
+
+        <div className="challenge-detail-grid">
+          <article className="challenge-detail-panel">
+            <h2>Instructions</h2>
+            <p>{challenge.description}</p>
+            {challenge.instructions && (
+              <div className="challenge-instructions">{challenge.instructions}</div>
+            )}
+
+            <div className="challenge-detail-meta-grid">
+              <div>
+                <span>Type</span>
+                <strong>{challenge.kind === 'multi_part' ? 'Multi-part' : 'Single goal'}</strong>
+              </div>
+              <div>
+                <span>Attempts</span>
+                <strong>{progress?.attemptCount || 0}</strong>
+              </div>
+              <div>
+                <span>Reward</span>
+                <strong>{getRewardSummary(challenge)}</strong>
+              </div>
+              <div>
+                <span>Version</span>
+                <strong>{challenge.version}</strong>
+              </div>
+            </div>
+          </article>
+
+          <aside className="challenge-detail-panel challenge-submit-panel">
+            <h2>Submit Proof</h2>
+            {!user ? (
+              <div className="challenge-submit-state">
+                <Lock size={22} aria-hidden="true" />
+                <p>Sign in to start this challenge and submit proof.</p>
+                <button
+                  type="button"
+                  onClick={() => navigate(`/auth?redirect=/challenges/${slug}`)}
+                >
+                  Sign in
+                </button>
+              </div>
+            ) : !progress || progress.status === 'not_started' ? (
+              <div className="challenge-submit-state">
+                <Trophy size={22} aria-hidden="true" />
+                <p>Start this challenge to track attempts and unlock the submission form.</p>
+                <button type="button" onClick={handleStart} disabled={starting}>
+                  {starting ? 'Starting...' : 'Start challenge'}
+                </button>
+              </div>
+            ) : isCompleted ? (
+              <div className="challenge-submit-state success">
+                <CheckCircle2 size={24} aria-hidden="true" />
+                <p>{getStatusCopy(progress)}</p>
+                {challenge.reward.enabled && (
+                  <div className="challenge-earned-summary">
+                    <span>Earned</span>
+                    <strong>{getRewardSummary(challenge)}</strong>
+                    <small>{getRewardStatusCopy(undefined, progress)}</small>
+                  </div>
+                )}
+                {progress.lastValidationMessage && <small>{progress.lastValidationMessage}</small>}
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="challenge-submit-form">
+                <label>
+                  Challenge secret
+                  <input
+                    type="text"
+                    value={secret}
+                    onChange={(event) => setSecret(event.target.value)}
+                    placeholder="Paste the secret value"
+                    disabled={submitting || rewardLocked}
+                  />
+                </label>
+                <button type="submit" disabled={submitting || rewardLocked}>
+                  <Send size={16} aria-hidden="true" />
+                  {submitting ? 'Submitting...' : 'Submit challenge'}
+                </button>
+                {progress.lastValidationMessage && <small>{progress.lastValidationMessage}</small>}
+              </form>
+            )}
+          </aside>
+        </div>
+      </section>
+
+      {rewardModalOpen && (
+        <div className="reward-celebration-overlay" role="dialog" aria-modal="true">
+          <motion.div
+            className="reward-celebration-modal"
+            initial={{ opacity: 0, scale: 0.92, y: 24 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            transition={{ type: 'spring', stiffness: 260, damping: 22 }}
+          >
+            <div className="reward-burst" aria-hidden="true">
+              {Array.from({ length: 14 }).map((_, index) => (
+                <span key={index} style={{ '--burst-index': index } as RewardBurstStyle} />
+              ))}
+            </div>
+
+            <div className="reward-celebration-icon" aria-hidden="true">
+              <Trophy size={34} />
+            </div>
+
+            <span className="reward-celebration-eyebrow">Challenge complete</span>
+            <h2>{challenge.title}</h2>
+            <p>{getRewardStatusCopy(lastSubmitReward, progress)}</p>
+
+            {challenge.reward.enabled && (
+              <div className="reward-celebration-totals">
+                <div>
+                  <span>Bits earned</span>
+                  <strong>{challenge.reward.bits}</strong>
+                </div>
+                <div>
+                  <span>XP earned</span>
+                  <strong>{challenge.reward.xpAmount || 0}</strong>
+                </div>
+              </div>
+            )}
+
+            <button type="button" onClick={() => setRewardModalOpen(false)}>
+              Continue
+            </button>
+          </motion.div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ChallengeDetail;

--- a/frontend/src/pages/Challenges.tsx
+++ b/frontend/src/pages/Challenges.tsx
@@ -1,79 +1,72 @@
-import { useState, useEffect } from 'react';
-import { motion } from 'motion/react';
-import { useAuth } from '../context/AuthContext';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Link2, ShieldCheck, Target, Star, Trophy, X } from 'lucide-react';
-import { rewardIntegrationAPI } from '../utils/api';
+import { motion } from 'motion/react';
+import { Link2, ShieldCheck, Star, Target, Trophy, X } from 'lucide-react';
+
+import { useAuth } from '../context/AuthContext';
+import { challengeAPI } from '../utils/api';
+import type { ChallengeListItem, ChallengeListResponse } from '../types/challenge';
 import type { ThemeProps } from '../types';
-import type { RewardIntegrationStatusResponse } from '../types/rewardIntegration';
 import './styles/Challenges.css';
 import '../pages/styles/Landing.css';
 
 type ChallengeTab = 'all' | 'single' | 'multi' | 'completed';
-type ChallengeType = 'single' | 'multi';
-type ChallengeDifficulty = 'Easy' | 'Medium' | 'Hard' | string;
 
-interface Challenge {
-  id: string;
-  title: string;
-  description: string;
-  difficulty: ChallengeDifficulty;
-  points: number;
-  type: ChallengeType;
-  completed?: boolean;
-  completedParts?: number;
-  parts?: number;
-}
+const completedStatuses = new Set(['completed', 'reward_pending', 'reward_sent', 'reward_failed']);
+
+const difficultyColors: Record<string, string> = {
+  easy: '#4ade80',
+  medium: '#fbbf24',
+  hard: '#f87171',
+  expert: '#c084fc',
+};
+
+const formatDifficulty = (difficulty: string): string => {
+  return difficulty.charAt(0).toUpperCase() + difficulty.slice(1);
+};
+
+const getChallengeStatusLabel = (challenge: ChallengeListItem): string => {
+  const status = challenge.progress?.status;
+  if (!status || status === 'not_started') return 'Not started';
+  if (status === 'in_progress') return 'In progress';
+  if (status === 'reward_failed') return 'Reward failed';
+  if (status === 'reward_sent') return 'Completed';
+  if (status === 'reward_pending') return 'Reward pending';
+  return 'Completed';
+};
 
 function Challenges({ theme: _theme }: ThemeProps) {
   const { user } = useAuth();
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<ChallengeTab>('all');
-  const [challenges] = useState<Challenge[]>([]);
+  const [challengeResponse, setChallengeResponse] = useState<ChallengeListResponse | null>(null);
   const [loading, setLoading] = useState(true);
-  const [rewardStatus, setRewardStatus] = useState<RewardIntegrationStatusResponse | null>(null);
-  const [rewardStatusLoading, setRewardStatusLoading] = useState<boolean>(false);
-  const [rewardStatusError, setRewardStatusError] = useState<string>('');
+  const [error, setError] = useState('');
   const [rewardGateDismissed, setRewardGateDismissed] = useState<boolean>(false);
   const rewardGateDismissKey = user
     ? `awsStudentHub:challengeRewardGateDismissed:${user.id || user._id || user.email}`
     : '';
 
   useEffect(() => {
-    const loadChallenges = async () => {
-      setLoading(false);
-    };
-    loadChallenges();
-  }, []);
-
-  useEffect(() => {
-    if (!user) {
-      setRewardStatus(null);
-      setRewardStatusError('');
-      return;
-    }
-
     let shouldUpdate = true;
-    setRewardStatusLoading(true);
-    setRewardStatusError('');
+    setLoading(true);
+    setError('');
 
-    rewardIntegrationAPI
-      .status()
-      .then((status) => {
+    challengeAPI
+      .list()
+      .then((response) => {
         if (shouldUpdate) {
-          setRewardStatus(status);
+          setChallengeResponse(response);
         }
       })
       .catch((err) => {
         if (shouldUpdate) {
-          setRewardStatusError(
-            err instanceof Error ? err.message : 'Failed to load Prizeversity link status'
-          );
+          setError(err instanceof Error ? err.message : 'Failed to load challenges');
         }
       })
       .finally(() => {
         if (shouldUpdate) {
-          setRewardStatusLoading(false);
+          setLoading(false);
         }
       });
 
@@ -91,6 +84,11 @@ function Challenges({ theme: _theme }: ThemeProps) {
     setRewardGateDismissed(localStorage.getItem(rewardGateDismissKey) === 'true');
   }, [rewardGateDismissKey]);
 
+  const rewardLink = challengeResponse?.rewardLink;
+  const challenges = challengeResponse?.challenges || [];
+  const rewardLinked = Boolean(rewardLink?.linked);
+  const rewardConfigured = Boolean(rewardLink?.configured);
+
   const handleSignIn = () => {
     navigate('/auth?redirect=/challenges');
   };
@@ -106,26 +104,13 @@ function Challenges({ theme: _theme }: ThemeProps) {
     setRewardGateDismissed(true);
   };
 
-  const filteredChallenges = challenges.filter((c) => {
-    if (activeTab === 'all') return true;
-    if (activeTab === 'single') return c.type === 'single';
-    if (activeTab === 'multi') return c.type === 'multi';
-    if (activeTab === 'completed') return c.completed;
+  const filteredChallenges = challenges.filter((challenge) => {
+    const completed = completedStatuses.has(challenge.progress?.status || '');
+    if (activeTab === 'single') return challenge.kind === 'single';
+    if (activeTab === 'multi') return challenge.kind === 'multi_part';
+    if (activeTab === 'completed') return completed;
     return true;
   });
-
-  const getDifficultyColor = (difficulty: ChallengeDifficulty): string => {
-    switch (difficulty) {
-      case 'Easy':
-        return '#4ade80';
-      case 'Medium':
-        return '#fbbf24';
-      case 'Hard':
-        return '#f87171';
-      default:
-        return '#94a3b8';
-    }
-  };
 
   return (
     <div className="landing-container">
@@ -151,7 +136,7 @@ function Challenges({ theme: _theme }: ThemeProps) {
             animate={{ opacity: 1 }}
             transition={{ delay: 0.2 }}
           >
-            Test your skills with OSINT-inspired challenges and earn rewards
+            Solve technical labs, prove completion, and sync rewards through your linked classroom.
           </motion.p>
         </div>
 
@@ -162,51 +147,47 @@ function Challenges({ theme: _theme }: ThemeProps) {
             animate={{ opacity: 1 }}
             transition={{ delay: 0.3 }}
           >
-            <p>Sign in to track your progress and earn points</p>
+            <p>Sign in to track progress and earn rewards.</p>
             <button onClick={handleSignIn}>Sign In</button>
           </motion.div>
         )}
 
-        {user && (!rewardStatus?.linked || !rewardGateDismissed) && (
+        {user && rewardLink && (!rewardLinked || !rewardGateDismissed) && (
           <motion.div
-            className={`challenges-reward-gate ${rewardStatus?.linked ? 'linked' : ''}`}
+            className={`challenges-reward-gate ${rewardLinked ? 'linked' : ''}`}
             initial={{ opacity: 0, y: 16 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.28 }}
           >
             <div className="reward-gate-icon" aria-hidden="true">
-              {rewardStatus?.linked ? <ShieldCheck size={26} /> : <Link2 size={26} />}
+              {rewardLinked ? <ShieldCheck size={26} /> : <Link2 size={26} />}
             </div>
             <div className="reward-gate-copy">
-              <span>{rewardStatus?.linked ? 'Rewards connected' : 'Required before play'}</span>
+              <span>{rewardLinked ? 'Rewards connected' : 'Required before rewards'}</span>
               <h3>
-                {rewardStatus?.linked
+                {rewardLinked
                   ? 'Prizeversity is linked for challenge rewards.'
-                  : 'Link Prizeversity to unlock rewardable challenges.'}
+                  : 'Link Prizeversity to complete rewardable challenges.'}
               </h3>
               <p>
-                {rewardStatusLoading
-                  ? 'Checking your classroom reward link...'
-                  : rewardStatusError
-                    ? rewardStatusError
-                    : rewardStatus?.linked
-                      ? `Completions will sync to ${rewardStatus.account?.matchedName || rewardStatus.account?.email || 'your Prizeversity classroom account'}.`
-                      : rewardStatus && !rewardStatus.configured
-                        ? 'An admin needs to configure a Prizeversity classroom instance before challenges can award progress.'
-                        : 'Use your AWS Student Hub profile to connect the Prizeversity classroom account that will receive challenge progress and rewards.'}
+                {rewardLinked
+                  ? 'Challenge completions will sync to your verified Prizeversity classroom account.'
+                  : rewardConfigured
+                    ? 'Use Account Settings to verify the classroom account that should receive challenge progress.'
+                    : 'An admin needs to configure a Prizeversity classroom instance before challenge rewards can be emitted.'}
               </p>
             </div>
-            {!rewardStatus?.linked && (
+            {!rewardLinked && (
               <button
                 type="button"
                 className="reward-gate-button"
                 onClick={handleLinkPrizeversity}
-                disabled={rewardStatusLoading || Boolean(rewardStatus && !rewardStatus.configured)}
+                disabled={!rewardConfigured}
               >
                 Link in Account
               </button>
             )}
-            {rewardStatus?.linked && (
+            {rewardLinked && (
               <button
                 type="button"
                 className="reward-gate-dismiss"
@@ -219,90 +200,96 @@ function Challenges({ theme: _theme }: ThemeProps) {
           </motion.div>
         )}
 
-        <motion.div
-          className="challenges-coming-soon"
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.35 }}
-        >
-          <span className="coming-soon-badge">Coming soon</span>
-          <h3>Challenge Hub is under active development</h3>
-          <p>
-            We are rebuilding the challenge experience with progress tracking, points, and rewards.
-            Check back here for updates as the new system rolls out.
-          </p>
-        </motion.div>
-
         <div className="challenges-tabs">
-          <button
-            className={activeTab === 'all' ? 'active' : ''}
-            onClick={() => setActiveTab('all')}
-          >
-            All Challenges
-          </button>
-          <button
-            className={activeTab === 'single' ? 'active' : ''}
-            onClick={() => setActiveTab('single')}
-          >
-            Single Goal
-          </button>
-          <button
-            className={activeTab === 'multi' ? 'active' : ''}
-            onClick={() => setActiveTab('multi')}
-          >
-            Multi-Part
-          </button>
-          <button
-            className={activeTab === 'completed' ? 'active' : ''}
-            onClick={() => setActiveTab('completed')}
-          >
-            Completed
-          </button>
+          {(['all', 'single', 'multi', 'completed'] as ChallengeTab[]).map((tab) => (
+            <button
+              key={tab}
+              className={activeTab === tab ? 'active' : ''}
+              onClick={() => setActiveTab(tab)}
+            >
+              {tab === 'all'
+                ? 'All Challenges'
+                : tab === 'single'
+                  ? 'Single Goal'
+                  : tab === 'multi'
+                    ? 'Multi-Part'
+                    : 'Completed'}
+            </button>
+          ))}
         </div>
+
+        {error && <div className="challenge-error-banner">{error}</div>}
 
         <div className="challenges-grid">
           {loading ? (
             <div className="challenges-loading">Loading challenges...</div>
           ) : filteredChallenges.length === 0 ? (
             <div className="challenges-empty">
-              New challenges are coming soon. Thanks for your patience while we finish building this
-              experience.
+              No published challenges match this view yet. Admins can publish challenges from the
+              admin dashboard.
             </div>
           ) : (
-            filteredChallenges.map((challenge, index) => (
-              <motion.div
-                key={challenge.id}
-                className={`challenge-card ${challenge.completed ? 'completed' : ''}`}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.4, delay: index * 0.1 }}
-                whileHover={{ scale: 1.02, y: -4 }}
-              >
-                <div className="challenge-card-header">
-                  <span
-                    className="challenge-difficulty"
-                    style={{ color: getDifficultyColor(challenge.difficulty) }}
-                  >
-                    {challenge.difficulty}
-                  </span>
-                  <span className="challenge-points">{challenge.points} pts</span>
-                </div>
+            filteredChallenges.map((challenge, index) => {
+              const completed = completedStatuses.has(challenge.progress?.status || '');
+              const locked = Boolean(
+                challenge.reward.enabled && user && rewardLink && !rewardLinked
+              );
 
-                <h3 className="challenge-title">{challenge.title}</h3>
-                <p className="challenge-description">{challenge.description}</p>
+              return (
+                <motion.article
+                  key={challenge.id}
+                  className={`challenge-card ${completed ? 'completed' : ''} ${locked ? 'locked' : ''}`}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.4, delay: index * 0.06 }}
+                  whileHover={{ scale: 1.02, y: -4 }}
+                >
+                  <div className="challenge-card-header">
+                    <span
+                      className="challenge-difficulty"
+                      style={{ color: difficultyColors[challenge.difficulty] || '#94a3b8' }}
+                    >
+                      {formatDifficulty(challenge.difficulty)}
+                    </span>
+                    {challenge.reward.enabled && (
+                      <span className="challenge-points">{challenge.reward.bits} bits</span>
+                    )}
+                  </div>
 
-                <div className="challenge-card-footer">
-                  <span className="challenge-type">
-                    {challenge.type === 'multi'
-                      ? `Multi-Part (${challenge.completedParts}/${challenge.parts})`
-                      : 'Single Goal'}
-                  </span>
-                  <button className="challenge-start-btn">
-                    {challenge.completed ? 'View' : 'Start'}
-                  </button>
-                </div>
-              </motion.div>
-            ))
+                  <h3 className="challenge-title">{challenge.title}</h3>
+                  <p className="challenge-description">{challenge.summary}</p>
+
+                  <div className="challenge-card-meta">
+                    <span>{challenge.kind === 'multi_part' ? 'Multi-part' : 'Single goal'}</span>
+                    {challenge.estimatedMinutes && <span>{challenge.estimatedMinutes} min</span>}
+                    <span>{getChallengeStatusLabel(challenge)}</span>
+                  </div>
+
+                  {locked && (
+                    <div className="challenge-lock-note">
+                      Link Prizeversity before submitting this rewardable challenge.
+                    </div>
+                  )}
+
+                  <div className="challenge-card-footer">
+                    <span className="challenge-type">
+                      {challenge.tags.length ? challenge.tags.slice(0, 2).join(' / ') : 'AWS Club'}
+                    </span>
+                    <button
+                      type="button"
+                      className="challenge-start-btn"
+                      onClick={() => navigate(`/challenges/${challenge.slug}`)}
+                    >
+                      {completed
+                        ? 'Review'
+                        : challenge.progress?.status === 'in_progress'
+                          ? 'Resume'
+                          : 'Start'}
+                    </button>
+                  </div>
+                </motion.article>
+              );
+            })
           )}
         </div>
 
@@ -316,18 +303,20 @@ function Challenges({ theme: _theme }: ThemeProps) {
           <div className="info-cards">
             <div className="info-card">
               <Target className="info-icon" size={32} />
-              <h3>Complete Challenges</h3>
-              <p>Solve OSINT-style puzzles that test your investigative and technical skills</p>
+              <h3>Start a Lab</h3>
+              <p>Open a challenge, follow the instructions, and submit proof from the lab.</p>
             </div>
             <div className="info-card">
               <Star className="info-icon" size={32} />
-              <h3>Earn Points</h3>
-              <p>Each challenge rewards you with points based on difficulty</p>
+              <h3>Validate Progress</h3>
+              <p>The backend validator checks your answer and records every attempt safely.</p>
             </div>
             <div className="info-card">
               <Trophy className="info-icon" size={32} />
-              <h3>Get Rewards</h3>
-              <p>Points sync with Prizeversity where you can redeem real rewards</p>
+              <h3>Sync Rewards</h3>
+              <p>
+                Completed rewardable challenges emit rewards to your linked Prizeversity account.
+              </p>
             </div>
           </div>
         </motion.div>

--- a/frontend/src/pages/styles/AdminDashboard.css
+++ b/frontend/src/pages/styles/AdminDashboard.css
@@ -96,6 +96,7 @@
 
 .dashboard-content,
 .users-content,
+.challenges-admin-content,
 .rewards-content,
 .queue-content {
   animation: fadeInUp 0.5s ease forwards;
@@ -281,7 +282,8 @@
 }
 
 .reward-form input,
-.reward-form textarea {
+.reward-form textarea,
+.reward-form select {
   width: 100%;
   background: var(--bg-primary);
   border: 2px solid rgba(var(--text-secondary-rgb), 0.18);
@@ -300,10 +302,48 @@
 }
 
 .reward-form input:focus,
-.reward-form textarea:focus {
+.reward-form textarea:focus,
+.reward-form select:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.1);
   outline: none;
+}
+
+.challenge-admin-two-col {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.challenge-admin-checkbox {
+  align-items: center;
+  display: flex !important;
+  gap: 10px !important;
+}
+
+.challenge-admin-checkbox input {
+  width: auto;
+}
+
+.challenge-admin-actions {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.challenge-admin-actions select,
+.challenge-admin-actions button {
+  background: var(--bg-primary);
+  border: 2px solid rgba(var(--text-secondary-rgb), 0.18);
+  border-radius: 12px;
+  color: var(--text-primary);
+  font: inherit;
+  padding: 10px 12px;
+}
+
+.challenge-admin-actions button {
+  cursor: pointer;
+  font-weight: 800;
 }
 
 .create-reward-instance-btn {

--- a/frontend/src/pages/styles/AdminDashboard.css
+++ b/frontend/src/pages/styles/AdminDashboard.css
@@ -628,6 +628,12 @@
   min-width: 60px;
 }
 
+.action-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+}
+
 .role-btn {
   background-color: var(--accent);
   color: white;
@@ -750,6 +756,16 @@
   font-family: var(--font-family);
 }
 
+.modal-eyebrow {
+  color: var(--accent);
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  margin-bottom: 10px;
+  text-transform: uppercase;
+}
+
 .modal-content p {
   color: var(--text-secondary);
   margin-bottom: 20px;
@@ -795,8 +811,50 @@
   margin-top: 30px;
 }
 
+.challenge-delete-modal {
+  max-width: 560px;
+  text-align: left;
+}
+
+.challenge-delete-modal .modal-actions {
+  justify-content: flex-end;
+}
+
+.challenge-delete-summary {
+  background: rgba(var(--text-primary-rgb), 0.04);
+  border: 1px solid rgba(var(--text-secondary-rgb), 0.12);
+  border-radius: 16px;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 6px 0 20px;
+  padding: 14px;
+}
+
+.challenge-delete-summary div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.challenge-delete-summary span {
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.challenge-delete-summary strong {
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  overflow-wrap: anywhere;
+}
+
 .cancel-btn,
-.confirm-btn {
+.confirm-btn,
+.modal-actions .ban-btn,
+.modal-actions .delete-btn {
   padding: 12px 30px;
   border: none;
   border-radius: 12px;
@@ -806,6 +864,12 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
   font-family: var(--font-family);
+}
+
+.modal-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
 }
 
 .cancel-btn {
@@ -964,8 +1028,18 @@
     flex-direction: column;
   }
 
+  .challenge-delete-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .challenge-delete-modal .modal-actions {
+    justify-content: stretch;
+  }
+
   .cancel-btn,
-  .confirm-btn {
+  .confirm-btn,
+  .modal-actions .ban-btn,
+  .modal-actions .delete-btn {
     padding: 14px 20px;
   }
 }

--- a/frontend/src/pages/styles/Challenges.css
+++ b/frontend/src/pages/styles/Challenges.css
@@ -261,6 +261,10 @@
   background: linear-gradient(135deg, var(--card-bg) 0%, rgba(74, 222, 128, 0.05) 100%);
 }
 
+.challenge-card.locked {
+  border-color: rgba(251, 191, 36, 0.45);
+}
+
 .challenge-card-header {
   display: flex;
   justify-content: space-between;
@@ -296,6 +300,50 @@
   flex-grow: 1;
 }
 
+.challenge-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.challenge-card-meta span {
+  border: 1px solid rgba(var(--text-secondary-rgb), 0.16);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  padding: 0.25rem 0.55rem;
+}
+
+.challenge-lock-note {
+  border: 1px solid rgba(251, 191, 36, 0.35);
+  border-radius: 12px;
+  color: #92400e;
+  background: rgba(251, 191, 36, 0.1);
+  font-size: 0.84rem;
+  line-height: 1.45;
+  padding: 0.75rem;
+}
+
+.challenge-error-banner,
+.challenge-success-banner {
+  border-radius: 16px;
+  margin-bottom: 1.5rem;
+  padding: 1rem 1.1rem;
+  text-align: center;
+}
+
+.challenge-error-banner {
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  background: rgba(239, 68, 68, 0.08);
+  color: #dc2626;
+}
+
+.challenge-success-banner {
+  border: 1px solid rgba(34, 197, 94, 0.25);
+  background: rgba(34, 197, 94, 0.09);
+  color: #15803d;
+}
+
 .challenge-card-footer {
   display: flex;
   justify-content: space-between;
@@ -326,6 +374,402 @@
 .challenge-start-btn:hover {
   background: var(--accent-hover);
   transform: translateY(-1px);
+}
+
+.challenge-detail-section {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 7rem 2rem 3rem;
+}
+
+.challenge-back-link {
+  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 1.5rem;
+  text-decoration: none;
+}
+
+.challenge-back-link:hover {
+  color: var(--accent-color);
+}
+
+.challenge-detail-hero {
+  background:
+    radial-gradient(circle at 10% 20%, rgba(255, 153, 0, 0.18), transparent 34%),
+    linear-gradient(135deg, rgba(35, 47, 62, 0.12), rgba(255, 153, 0, 0.08)), var(--card-bg);
+  border: 1px solid rgba(255, 153, 0, 0.28);
+  border-radius: 24px;
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-bottom: 1.5rem;
+  padding: 2rem;
+}
+
+.challenge-detail-eyebrow {
+  color: var(--accent-color);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.challenge-detail-hero h1 {
+  color: var(--text-primary);
+  font-size: clamp(2rem, 5vw, 3.6rem);
+  line-height: 1.05;
+  margin: 0.45rem 0 0.8rem;
+}
+
+.challenge-detail-hero p {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  margin: 0;
+  max-width: 760px;
+}
+
+.challenge-detail-status {
+  align-items: center;
+  background: rgba(34, 197, 94, 0.12);
+  border: 1px solid rgba(34, 197, 94, 0.22);
+  border-radius: 999px;
+  color: #15803d;
+  display: inline-flex;
+  flex: 0 0 auto;
+  gap: 0.55rem;
+  height: fit-content;
+  padding: 0.7rem 0.95rem;
+}
+
+.challenge-detail-gate {
+  align-items: center;
+  background: rgba(251, 191, 36, 0.1);
+  border: 1px solid rgba(251, 191, 36, 0.28);
+  border-radius: 18px;
+  color: var(--text-primary);
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+}
+
+.challenge-detail-gate div {
+  display: grid;
+  flex: 1;
+  gap: 0.2rem;
+}
+
+.challenge-detail-gate span {
+  color: var(--text-secondary);
+}
+
+.challenge-detail-gate button,
+.challenge-submit-state button,
+.challenge-submit-form button {
+  align-items: center;
+  background: var(--accent-color);
+  border: none;
+  border-radius: 999px;
+  color: white;
+  cursor: pointer;
+  display: inline-flex;
+  font-weight: 800;
+  gap: 0.45rem;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+}
+
+.challenge-detail-gate button:disabled,
+.challenge-submit-state button:disabled,
+.challenge-submit-form button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.challenge-detail-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: minmax(0, 1fr) 360px;
+}
+
+.challenge-detail-panel {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 22px;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  padding: 1.5rem;
+}
+
+.challenge-detail-panel h2 {
+  color: var(--text-primary);
+  margin: 0 0 0.85rem;
+}
+
+.challenge-detail-panel p,
+.challenge-instructions {
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+.challenge-instructions {
+  border-left: 3px solid var(--accent-color);
+  margin-top: 1rem;
+  padding-left: 1rem;
+  white-space: pre-wrap;
+}
+
+.challenge-detail-meta-grid {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  margin-top: 1.5rem;
+}
+
+.challenge-detail-meta-grid div {
+  background: rgba(var(--text-primary-rgb), 0.04);
+  border-radius: 14px;
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.85rem;
+}
+
+.challenge-detail-meta-grid span {
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.challenge-detail-meta-grid strong {
+  color: var(--text-primary);
+}
+
+.challenge-submit-panel {
+  height: fit-content;
+}
+
+.challenge-submit-state {
+  align-items: center;
+  color: var(--text-secondary);
+  display: grid;
+  gap: 0.85rem;
+  justify-items: start;
+}
+
+.challenge-submit-state.success {
+  color: #15803d;
+}
+
+.challenge-earned-summary {
+  background: rgba(34, 197, 94, 0.1);
+  border: 1px solid rgba(34, 197, 94, 0.22);
+  border-radius: 16px;
+  color: var(--text-primary);
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.9rem 1rem;
+  width: 100%;
+}
+
+.challenge-earned-summary span {
+  color: #15803d;
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.challenge-earned-summary strong {
+  color: var(--text-primary);
+  font-size: 1.15rem;
+}
+
+.challenge-earned-summary small {
+  color: var(--text-secondary);
+}
+
+.challenge-submit-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.challenge-submit-form label {
+  color: var(--text-secondary);
+  display: grid;
+  font-size: 0.86rem;
+  font-weight: 800;
+  gap: 0.45rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.challenge-submit-form input {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  color: var(--text-primary);
+  font-size: 1rem;
+  padding: 0.9rem 1rem;
+  text-transform: none;
+}
+
+.challenge-submit-form input:focus {
+  border-color: var(--accent-color);
+  outline: none;
+}
+
+.reward-celebration-overlay {
+  align-items: center;
+  background: rgba(15, 23, 42, 0.58);
+  backdrop-filter: blur(10px);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: 1rem;
+  position: fixed;
+  z-index: 1000;
+}
+
+.reward-celebration-modal {
+  background:
+    radial-gradient(circle at 50% 0%, rgba(255, 153, 0, 0.18), transparent 42%), var(--card-bg);
+  border: 1px solid rgba(255, 153, 0, 0.34);
+  border-radius: 28px;
+  box-shadow: 0 30px 90px rgba(15, 23, 42, 0.34);
+  max-width: 520px;
+  overflow: hidden;
+  padding: 2rem;
+  position: relative;
+  text-align: center;
+  width: 100%;
+}
+
+.reward-burst {
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+.reward-burst span {
+  --burst-angle: calc(var(--burst-index) * 25.714deg);
+  animation: rewardBurst 1.2s ease-out both;
+  background: linear-gradient(135deg, var(--accent-color), #16a34a);
+  border-radius: 999px;
+  height: 0.42rem;
+  left: 50%;
+  opacity: 0;
+  position: absolute;
+  top: 5.1rem;
+  transform: rotate(var(--burst-angle)) translateY(0);
+  transform-origin: center;
+  width: 1.1rem;
+}
+
+@keyframes rewardBurst {
+  0% {
+    opacity: 0;
+    transform: rotate(var(--burst-angle)) translateY(0) scale(0.4);
+  }
+  18% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: rotate(var(--burst-angle)) translateY(-8.5rem) scale(1);
+  }
+}
+
+.reward-celebration-icon {
+  align-items: center;
+  animation: rewardPulse 1.3s ease-in-out infinite;
+  background: rgba(255, 153, 0, 0.16);
+  border: 1px solid rgba(255, 153, 0, 0.28);
+  border-radius: 22px;
+  color: var(--accent-color);
+  display: inline-flex;
+  height: 4.5rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+  position: relative;
+  width: 4.5rem;
+  z-index: 1;
+}
+
+@keyframes rewardPulse {
+  0%,
+  100% {
+    transform: translateY(0) scale(1);
+  }
+  50% {
+    transform: translateY(-3px) scale(1.03);
+  }
+}
+
+.reward-celebration-eyebrow {
+  color: var(--accent-color);
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.reward-celebration-modal h2 {
+  color: var(--text-primary);
+  font-size: 2rem;
+  line-height: 1.1;
+  margin: 0.45rem 0 0.75rem;
+}
+
+.reward-celebration-modal p {
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin: 0 auto 1.25rem;
+  max-width: 34rem;
+}
+
+.reward-celebration-totals {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 1.25rem 0;
+}
+
+.reward-celebration-totals div {
+  background: rgba(var(--text-primary-rgb), 0.045);
+  border: 1px solid rgba(var(--text-secondary-rgb), 0.12);
+  border-radius: 18px;
+  display: grid;
+  gap: 0.25rem;
+  padding: 1rem;
+}
+
+.reward-celebration-totals span {
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.reward-celebration-totals strong {
+  color: var(--text-primary);
+  font-size: 2rem;
+}
+
+.reward-celebration-modal button {
+  background: var(--accent-color);
+  border: none;
+  border-radius: 999px;
+  color: white;
+  cursor: pointer;
+  font-weight: 900;
+  padding: 0.85rem 1.35rem;
+  width: 100%;
 }
 
 .challenges-loading,
@@ -408,6 +852,20 @@
   }
 
   .challenges-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .challenge-detail-section {
+    padding: 6rem 1rem 2rem;
+  }
+
+  .challenge-detail-hero,
+  .challenge-detail-gate {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .challenge-detail-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/types/challenge.ts
+++ b/frontend/src/types/challenge.ts
@@ -1,0 +1,147 @@
+export type ChallengeStatus = 'draft' | 'published' | 'archived';
+export type ChallengeKind = 'single' | 'multi_part';
+export type ChallengeDifficulty = 'easy' | 'medium' | 'hard' | 'expert';
+export type ChallengeProgressStatus =
+  | 'not_started'
+  | 'in_progress'
+  | 'completed'
+  | 'reward_pending'
+  | 'reward_sent'
+  | 'reward_failed';
+export type ChallengeXpMode = 'none' | 'classroom' | 'custom';
+
+export interface ChallengeRewardPreview {
+  enabled: boolean;
+  bits: number;
+  xpAmount?: number;
+  xpMode?: ChallengeXpMode;
+}
+
+export interface ChallengeRewardConfig extends ChallengeRewardPreview {
+  activityName?: string;
+  description?: string;
+  stats?: {
+    multiplier?: number;
+    luck?: number;
+    shield?: number;
+    discount?: number;
+  };
+  applyGroupMultipliers?: boolean;
+  applyPersonalMultipliers?: boolean;
+}
+
+export interface ChallengeProgress {
+  id?: string;
+  challengeId?: string;
+  challengeKey?: string;
+  challengeVersion?: number;
+  status: ChallengeProgressStatus;
+  attemptCount: number;
+  startedAt?: string | null;
+  lastSubmittedAt?: string | null;
+  completedAt?: string | null;
+  rewardEmissionId?: string | null;
+  completionEventId?: string;
+  lastValidationMessage?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface ChallengeListItem {
+  id: string;
+  key: string;
+  slug: string;
+  title: string;
+  summary: string;
+  description?: string;
+  instructions?: string;
+  kind: ChallengeKind;
+  difficulty: ChallengeDifficulty;
+  estimatedMinutes?: number;
+  tags: string[];
+  version: number;
+  startsAt?: string | null;
+  endsAt?: string | null;
+  reward: ChallengeRewardPreview;
+  progress?: ChallengeProgress;
+}
+
+export interface ChallengeDetail extends ChallengeListItem {
+  description: string;
+  instructions?: string;
+}
+
+export interface ChallengeRewardLinkSummary {
+  required: boolean;
+  linked: boolean;
+  configured: boolean;
+}
+
+export interface ChallengeListResponse {
+  challenges: ChallengeListItem[];
+  rewardLink: ChallengeRewardLinkSummary;
+}
+
+export interface ChallengeDetailResponse {
+  challenge: ChallengeDetail;
+  rewardLink: ChallengeRewardLinkSummary;
+}
+
+export interface ChallengeProgressResponse {
+  challenge: ChallengeDetail;
+  progress: ChallengeProgress;
+}
+
+export interface ChallengeSubmitResponse {
+  accepted: boolean;
+  completed: boolean;
+  message: string;
+  progress: ChallengeProgress;
+  reward?: {
+    status: 'not_required' | 'sent' | 'already_sent' | 'failed';
+    emissionId?: string;
+    message?: string;
+  };
+}
+
+export interface AdminChallenge extends ChallengeDetail {
+  status: ChallengeStatus;
+  validation: Record<string, unknown>;
+  reward: ChallengeRewardConfig;
+  maxAttempts?: number;
+  publishedAt?: string | null;
+  archivedAt?: string | null;
+  createdBy?: string;
+  updatedBy?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface AdminChallengeListResponse {
+  items: AdminChallenge[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export interface AdminChallengePayload {
+  key?: string;
+  slug?: string;
+  title: string;
+  summary: string;
+  description: string;
+  instructions?: string;
+  status?: ChallengeStatus;
+  kind?: ChallengeKind;
+  difficulty?: ChallengeDifficulty;
+  estimatedMinutes?: number;
+  tags?: string[];
+  maxAttempts?: number;
+  validation: Record<string, unknown>;
+  reward?: Partial<ChallengeRewardConfig>;
+}
+
+export interface AdminChallengeResponse {
+  message?: string;
+  challenge: AdminChallenge;
+}

--- a/frontend/src/types/challenge.ts
+++ b/frontend/src/types/challenge.ts
@@ -145,3 +145,11 @@ export interface AdminChallengeResponse {
   message?: string;
   challenge: AdminChallenge;
 }
+
+export interface AdminChallengeDeleteResponse {
+  message?: string;
+  deleted: true;
+  challengeId: string;
+  progressDeleted: number;
+  submissionsDeleted: number;
+}

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,6 +1,17 @@
 import type { AdminStats, EmailQueueEntry } from '../types/admin';
 import type { ApiResponse } from '../types/api';
 import type { AuthResponse, LoginCredentials, SignupPayload } from '../types/auth';
+import type {
+  AdminChallengeListResponse,
+  AdminChallengePayload,
+  AdminChallengeResponse,
+  ChallengeDetailResponse,
+  ChallengeListResponse,
+  ChallengeProgressResponse,
+  ChallengeSubmitResponse,
+  ChallengeProgressStatus,
+  ChallengeStatus,
+} from '../types/challenge';
 import type { Event as FrontendEvent, EventFormPayload } from '../types/event';
 import type {
   RewardIntegrationInstance,
@@ -493,6 +504,36 @@ export const rewardIntegrationAPI = {
   },
 };
 
+export const challengeAPI = {
+  list: async (): Promise<ChallengeListResponse> => {
+    return apiRequest('/challenges');
+  },
+
+  get: async (slug: string): Promise<ChallengeDetailResponse> => {
+    return apiRequest(`/challenges/${encodeURIComponent(slug)}`);
+  },
+
+  progress: async (slug: string): Promise<ChallengeProgressResponse> => {
+    return apiRequest(`/challenges/${encodeURIComponent(slug)}/progress`);
+  },
+
+  start: async (slug: string): Promise<ChallengeProgressResponse> => {
+    return apiRequest(`/challenges/${encodeURIComponent(slug)}/start`, {
+      method: 'POST',
+    });
+  },
+
+  submit: async (
+    slug: string,
+    payload: Record<string, unknown>
+  ): Promise<ChallengeSubmitResponse> => {
+    return apiRequest(`/challenges/${encodeURIComponent(slug)}/submit`, {
+      method: 'POST',
+      body: JSON.stringify({ payload }),
+    });
+  },
+};
+
 interface RewardIntegrationInstancesResponse {
   instances: RewardIntegrationInstance[];
 }
@@ -723,6 +764,69 @@ export const adminAPI = {
     return apiRequest(`/admin/reward-integrations/${instanceId}`, {
       method: 'DELETE',
     });
+  },
+
+  listChallenges: async (
+    status?: ChallengeStatus,
+    search = '',
+    page = 1,
+    limit = 25
+  ): Promise<AdminChallengeListResponse> => {
+    const params = new URLSearchParams({
+      page: String(page),
+      limit: String(limit),
+      ...(status && { status }),
+      ...(search && { search }),
+    });
+    return apiRequest(`/admin/challenges?${params}`);
+  },
+
+  createChallenge: async (payload: AdminChallengePayload): Promise<AdminChallengeResponse> => {
+    return apiRequest('/admin/challenges', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  },
+
+  updateChallenge: async (
+    challengeId: string,
+    payload: Partial<AdminChallengePayload>
+  ): Promise<AdminChallengeResponse> => {
+    return apiRequest(`/admin/challenges/${challengeId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    });
+  },
+
+  publishChallenge: async (challengeId: string): Promise<AdminChallengeResponse> => {
+    return apiRequest(`/admin/challenges/${challengeId}/publish`, {
+      method: 'POST',
+    });
+  },
+
+  archiveChallenge: async (challengeId: string): Promise<AdminChallengeResponse> => {
+    return apiRequest(`/admin/challenges/${challengeId}/archive`, {
+      method: 'POST',
+    });
+  },
+
+  listChallengeProgress: async (
+    challengeId: string,
+    status?: ChallengeProgressStatus,
+    page = 1,
+    limit = 25
+  ): Promise<{
+    items: ChallengeProgressResponse['progress'][];
+    total: number;
+    page: number;
+    limit: number;
+  }> => {
+    const params = new URLSearchParams({
+      page: String(page),
+      limit: String(limit),
+      ...(status && { status }),
+    });
+    return apiRequest(`/admin/challenges/${challengeId}/progress?${params}`);
   },
 };
 

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -2,6 +2,7 @@ import type { AdminStats, EmailQueueEntry } from '../types/admin';
 import type { ApiResponse } from '../types/api';
 import type { AuthResponse, LoginCredentials, SignupPayload } from '../types/auth';
 import type {
+  AdminChallengeDeleteResponse,
   AdminChallengeListResponse,
   AdminChallengePayload,
   AdminChallengeResponse,
@@ -807,6 +808,12 @@ export const adminAPI = {
   archiveChallenge: async (challengeId: string): Promise<AdminChallengeResponse> => {
     return apiRequest(`/admin/challenges/${challengeId}/archive`, {
       method: 'POST',
+    });
+  },
+
+  deleteChallenge: async (challengeId: string): Promise<AdminChallengeDeleteResponse> => {
+    return apiRequest(`/admin/challenges/${challengeId}`, {
+      method: 'DELETE',
     });
   },
 


### PR DESCRIPTION
Adds the API-backed challenge hub, challenge detail flow, admin challenge management, and rollout wiring for the agnostic challenge system.

The user-facing challenge flow now loads published challenges from the backend, shows progress/reward state, gates rewardable submissions behind Prizeversity linking, supports challenge start/submission, and displays completed rewards with bits, XP, sync status, and a non-emoji completion celebration.

The admin dashboard now includes challenge catalog management for creating, publishing, archiving, and reviewing challenges. Shared frontend challenge types and API helpers were added so the UI is wired against the backend challenge contracts instead of hardcoded challenge data.

Also adds the AWS Cloud Security Lab seed path and rollout documentation so the existing AWS cyber challenge can move onto the agnostic challenge system cleanly.