### PR TITLE
feat: add Bloom-filtered live member search

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -9,6 +9,7 @@ import User from '../models/User';
 import type { UserGrade } from '../models/User';
 import { createChallengeUser } from '../services/awsProvision';
 import { sendResetCode } from '../services/emailService';
+import { memberSearchIndex } from '../services/memberSearchIndex';
 import logger from '../config/logger';
 
 const log = logger.child({ module: 'authController' });
@@ -869,7 +870,7 @@ export const getPublicProfile = async (req: Request, res: Response): Promise<voi
 
 export const searchUsers = async (req: Request, res: Response): Promise<void> => {
   try {
-    const q = queryString(req.query.q);
+    const q = queryString(req.query.q).trim();
     const limit = parseInteger(req.query.limit, 10);
 
     if (!q || q.length < 2) {
@@ -880,7 +881,24 @@ export const searchUsers = async (req: Request, res: Response): Promise<void> =>
       return;
     }
 
-    const searchRegex = new RegExp(q, 'i');
+    if (q.length > 64) {
+      res.status(400).json({
+        success: false,
+        error: 'Search query cannot exceed 64 characters',
+      });
+      return;
+    }
+
+    if (await memberSearchIndex.isDefinitelyMissing(q)) {
+      res.json({
+        success: true,
+        users: [],
+      });
+      return;
+    }
+
+    const escapedQuery = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const searchRegex = new RegExp(escapedQuery, 'i');
     const searchLimit = Math.min(limit, 20);
 
     const users = await User.find({

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -285,6 +285,8 @@ const userSchema = new Schema<IUser, UserModel, IUserMethods>(
   }
 );
 
+userSchema.index({ updatedAt: -1 });
+
 userSchema.pre('save', async function (next) {
   if (!this.isModified('password')) {
     next();

--- a/backend/src/services/memberSearchIndex.ts
+++ b/backend/src/services/memberSearchIndex.ts
@@ -1,0 +1,163 @@
+import logger from '../config/logger';
+import User from '../models/User';
+import { BloomFilter } from '../utils/BloomFilter';
+
+const log = logger.child({ module: 'memberSearchIndex' });
+
+const MIN_QUERY_LENGTH = 2;
+const MAX_QUERY_LENGTH = 64;
+const MAX_FILTER_INSERTIONS = 2_000_000;
+const FALSE_POSITIVE_RATE = 0.01;
+const ASCII_SEARCH_PATTERN = /^[a-z0-9_ .'-]+$/;
+
+interface SearchableMember {
+  username?: string;
+  fullName?: string;
+}
+
+interface MemberCollectionVersion {
+  _id: unknown;
+  updatedAt?: Date;
+}
+
+interface SearchIndexSnapshot {
+  collectionFingerprint: string;
+  filter: BloomFilter | null;
+}
+
+const normalizeSearchValue = (value: string): string => {
+  return value.normalize('NFKC').toLowerCase();
+};
+
+const countSearchableSubstrings = (value: string): number => {
+  const maxLength = Math.min(MAX_QUERY_LENGTH, value.length);
+  let count = 0;
+
+  for (let length = MIN_QUERY_LENGTH; length <= maxLength; length += 1) {
+    count += value.length - length + 1;
+  }
+
+  return count;
+};
+
+const addSearchableSubstrings = (filter: BloomFilter, value: string): void => {
+  const maxLength = Math.min(MAX_QUERY_LENGTH, value.length);
+
+  for (let length = MIN_QUERY_LENGTH; length <= maxLength; length += 1) {
+    for (let start = 0; start <= value.length - length; start += 1) {
+      filter.add(value.slice(start, start + length));
+    }
+  }
+};
+
+class MemberSearchIndex {
+  private snapshot: SearchIndexSnapshot | null = null;
+  private rebuildPromise: Promise<SearchIndexSnapshot | null> | null = null;
+
+  async isDefinitelyMissing(query: string): Promise<boolean> {
+    const normalizedQuery = normalizeSearchValue(query);
+
+    if (
+      normalizedQuery.length < MIN_QUERY_LENGTH ||
+      normalizedQuery.length > MAX_QUERY_LENGTH ||
+      !ASCII_SEARCH_PATTERN.test(normalizedQuery)
+    ) {
+      return false;
+    }
+
+    try {
+      const collectionFingerprint = await this.getCollectionFingerprint();
+
+      if (this.snapshot?.collectionFingerprint !== collectionFingerprint) {
+        this.snapshot = await this.rebuild();
+      }
+
+      return this.snapshot?.filter ? !this.snapshot.filter.mightContain(normalizedQuery) : false;
+    } catch (error: unknown) {
+      log.warn('member search bloom index unavailable; using database search.', error);
+      return false;
+    }
+  }
+
+  private async rebuild(): Promise<SearchIndexSnapshot | null> {
+    if (this.rebuildPromise) {
+      return this.rebuildPromise;
+    }
+
+    this.rebuildPromise = this.buildStableSnapshot();
+
+    try {
+      return await this.rebuildPromise;
+    } finally {
+      this.rebuildPromise = null;
+    }
+  }
+
+  private async buildStableSnapshot(): Promise<SearchIndexSnapshot | null> {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const fingerprintBefore = await this.getCollectionFingerprint();
+      const members = (await User.find({})
+        .select('username fullName')
+        .lean()) as SearchableMember[];
+      const fingerprintAfter = await this.getCollectionFingerprint();
+
+      if (fingerprintBefore !== fingerprintAfter) {
+        continue;
+      }
+
+      const searchableValues = members.flatMap((member) =>
+        [member.username, member.fullName]
+          .filter((value): value is string => Boolean(value))
+          .map(normalizeSearchValue)
+      );
+      const insertionCount = searchableValues.reduce(
+        (total, value) => total + countSearchableSubstrings(value),
+        0
+      );
+
+      if (insertionCount > MAX_FILTER_INSERTIONS) {
+        log.warn(
+          `member search bloom index disabled: ${insertionCount} substrings exceed the configured limit.`
+        );
+        return {
+          collectionFingerprint: fingerprintAfter,
+          filter: null,
+        };
+      }
+
+      const filter = new BloomFilter(Math.max(1, insertionCount), FALSE_POSITIVE_RATE);
+      searchableValues.forEach((value) => addSearchableSubstrings(filter, value));
+
+      log.info(
+        `member search bloom index rebuilt for ${members.length} members and ${insertionCount} substrings.`
+      );
+
+      return {
+        collectionFingerprint: fingerprintAfter,
+        filter,
+      };
+    }
+
+    log.warn('member collection changed during bloom index rebuild; using database search.');
+    return null;
+  }
+
+  private async getCollectionFingerprint(): Promise<string> {
+    const [memberCount, latestMember] = await Promise.all([
+      User.countDocuments({}),
+      User.findOne({}).sort({ updatedAt: -1, _id: -1 }).select('_id updatedAt').lean(),
+    ]);
+    const version = latestMember as MemberCollectionVersion | null;
+    const updatedAt = version?.updatedAt ? new Date(version.updatedAt).getTime() : 0;
+
+    return `${memberCount}:${String(version?._id ?? '')}:${updatedAt}`;
+  }
+}
+
+const globalWithMemberSearchIndex = globalThis as typeof globalThis & {
+  memberSearchIndex?: MemberSearchIndex;
+};
+
+export const memberSearchIndex =
+  globalWithMemberSearchIndex.memberSearchIndex ??
+  (globalWithMemberSearchIndex.memberSearchIndex = new MemberSearchIndex());

--- a/backend/src/utils/BloomFilter.ts
+++ b/backend/src/utils/BloomFilter.ts
@@ -1,0 +1,78 @@
+const DEFAULT_FALSE_POSITIVE_RATE = 0.01;
+const MAX_HASH_COUNT = 16;
+
+const hashString = (value: string, seed: number): number => {
+  let hash = seed >>> 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x5bd1e995);
+    hash ^= hash >>> 15;
+  }
+
+  return hash >>> 0;
+};
+
+export class BloomFilter {
+  readonly bitCount: number;
+  readonly hashCount: number;
+
+  private readonly bits: Uint8Array;
+
+  constructor(expectedItems: number, falsePositiveRate = DEFAULT_FALSE_POSITIVE_RATE) {
+    if (!Number.isInteger(expectedItems) || expectedItems < 1) {
+      throw new RangeError('expectedItems must be a positive integer');
+    }
+
+    if (falsePositiveRate <= 0 || falsePositiveRate >= 1) {
+      throw new RangeError('falsePositiveRate must be between 0 and 1');
+    }
+
+    const naturalLogOfTwo = Math.log(2);
+    this.bitCount = Math.max(
+      8,
+      Math.ceil(
+        (-expectedItems * Math.log(falsePositiveRate)) / (naturalLogOfTwo * naturalLogOfTwo)
+      )
+    );
+    this.hashCount = Math.min(
+      MAX_HASH_COUNT,
+      Math.max(1, Math.round((this.bitCount / expectedItems) * naturalLogOfTwo))
+    );
+    this.bits = new Uint8Array(Math.ceil(this.bitCount / 8));
+  }
+
+  add(value: string): void {
+    for (const bitIndex of this.getBitIndexes(value)) {
+      const byteIndex = Math.floor(bitIndex / 8);
+      const bitOffset = bitIndex % 8;
+      this.bits[byteIndex] |= 1 << bitOffset;
+    }
+  }
+
+  mightContain(value: string): boolean {
+    for (const bitIndex of this.getBitIndexes(value)) {
+      const byteIndex = Math.floor(bitIndex / 8);
+      const bitOffset = bitIndex % 8;
+
+      if ((this.bits[byteIndex] & (1 << bitOffset)) === 0) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private getBitIndexes(value: string): number[] {
+    const firstHash = hashString(value, 0x811c9dc5);
+    const secondHash = (hashString(value, 0x9747b28c) | 1) >>> 0;
+    const indexes: number[] = [];
+
+    for (let index = 0; index < this.hashCount; index += 1) {
+      const combinedHash = (firstHash + Math.imul(index, secondHash)) >>> 0;
+      indexes.push(combinedHash % this.bitCount);
+    }
+
+    return indexes;
+  }
+}

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ChangeEvent, KeyboardEvent, MouseEvent, SyntheticEvent } from 'react';
 import './styles/Landing.css';
 import { motion } from 'motion/react';
@@ -24,6 +24,10 @@ function Landing({ theme: _theme }: ThemeProps) {
   const [searchPerformed, setSearchPerformed] = useState(false);
   const [showReferralLink, setShowReferralLink] = useState(false);
   const [referralCopied, setReferralCopied] = useState(false);
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const referralTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const activeSearchControllerRef = useRef<AbortController | null>(null);
+  const latestSearchRequestRef = useRef(0);
   const navigate = useNavigate();
   const { user } = useAuth();
 
@@ -73,36 +77,130 @@ function Landing({ theme: _theme }: ThemeProps) {
     fetchRecentUsers();
   }, []);
 
-  const handleSearch = async () => {
-    if (!searchQuery.trim() || searchQuery.length < 2) {
+  const performSearch = useCallback(async (rawQuery: string) => {
+    const query = rawQuery.trim();
+
+    if (query.length < 2) {
       return;
     }
 
+    activeSearchControllerRef.current?.abort();
+    const controller = new AbortController();
+    const requestId = latestSearchRequestRef.current + 1;
+    activeSearchControllerRef.current = controller;
+    latestSearchRequestRef.current = requestId;
+
+    if (referralTimerRef.current) {
+      clearTimeout(referralTimerRef.current);
+      referralTimerRef.current = null;
+    }
+
     setIsSearching(true);
-    setSearchPerformed(true);
+    setSearchPerformed(false);
     setShowReferralLink(false);
 
     try {
-      const response = await authAPI.searchUsers(searchQuery.trim(), 5);
+      const response = await authAPI.searchUsers(query, 5, controller.signal);
+
+      if (requestId !== latestSearchRequestRef.current) {
+        return;
+      }
+
       setSearchResults(response.users || []);
+      setSearchPerformed(true);
 
       if (!response.users || response.users.length === 0) {
-        setTimeout(() => setShowReferralLink(true), 500);
+        referralTimerRef.current = setTimeout(() => {
+          if (requestId === latestSearchRequestRef.current) {
+            setShowReferralLink(true);
+          }
+        }, 500);
       }
     } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        return;
+      }
+
+      if (requestId !== latestSearchRequestRef.current) {
+        return;
+      }
+
       console.error('error searching users.', error);
       setSearchResults([]);
-      setTimeout(() => setShowReferralLink(true), 500);
+      setSearchPerformed(true);
+      referralTimerRef.current = setTimeout(() => {
+        if (requestId === latestSearchRequestRef.current) {
+          setShowReferralLink(true);
+        }
+      }, 500);
     } finally {
-      setIsSearching(false);
+      if (requestId === latestSearchRequestRef.current) {
+        setIsSearching(false);
+      }
     }
+  }, []);
+
+  useEffect(() => {
+    const query = searchQuery.trim();
+
+    if (searchDebounceRef.current) {
+      clearTimeout(searchDebounceRef.current);
+      searchDebounceRef.current = null;
+    }
+
+    activeSearchControllerRef.current?.abort();
+    activeSearchControllerRef.current = null;
+    latestSearchRequestRef.current += 1;
+
+    if (referralTimerRef.current) {
+      clearTimeout(referralTimerRef.current);
+      referralTimerRef.current = null;
+    }
+
+    setIsSearching(false);
+    setSearchPerformed(false);
+    setShowReferralLink(false);
+    setReferralCopied(false);
+
+    if (query.length < 2) {
+      setSearchResults([]);
+      return;
+    }
+
+    searchDebounceRef.current = setTimeout(() => {
+      searchDebounceRef.current = null;
+      void performSearch(query);
+    }, 300);
+
+    return () => {
+      if (searchDebounceRef.current) {
+        clearTimeout(searchDebounceRef.current);
+        searchDebounceRef.current = null;
+      }
+    };
+  }, [performSearch, searchQuery]);
+
+  useEffect(() => {
+    return () => {
+      activeSearchControllerRef.current?.abort();
+      if (referralTimerRef.current) clearTimeout(referralTimerRef.current);
+    };
+  }, []);
+
+  const handleSearch = () => {
+    if (searchDebounceRef.current) {
+      clearTimeout(searchDebounceRef.current);
+      searchDebounceRef.current = null;
+    }
+
+    void performSearch(searchQuery);
   };
 
   const handleSearchInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setSearchQuery(value);
 
-    if (!value.trim()) {
+    if (value.trim().length < 2) {
       setSearchResults([]);
       setSearchPerformed(false);
       setShowReferralLink(false);
@@ -110,8 +208,9 @@ function Landing({ theme: _theme }: ThemeProps) {
     }
   };
 
-  const handleSearchKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
+  const handleSearchKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
+      e.preventDefault();
       handleSearch();
     }
   };
@@ -369,13 +468,21 @@ function Landing({ theme: _theme }: ThemeProps) {
             >
               <input
                 type="text"
-                placeholder="Search by name, username, or email..."
+                placeholder="Search by name or username..."
                 value={searchQuery}
                 onChange={handleSearchInputChange}
-                onKeyPress={handleSearchKeyPress}
+                onKeyDown={handleSearchKeyDown}
                 className="search-input"
+                autoComplete="off"
+                aria-label="Search members by name or username"
+                aria-controls="member-search-results"
               />
-              <button className="search-button" onClick={handleSearch} disabled={isSearching}>
+              <button
+                type="button"
+                className="search-button"
+                onClick={handleSearch}
+                disabled={isSearching || searchQuery.trim().length < 2}
+              >
                 {isSearching ? 'Searching...' : 'Search'}
               </button>
             </motion.div>
@@ -415,6 +522,7 @@ function Landing({ theme: _theme }: ThemeProps) {
 
             {searchPerformed && searchResults.length > 0 && (
               <motion.div
+                id="member-search-results"
                 className="search-results-container"
                 initial={{ opacity: 0, y: 20 }}
                 whileInView={{ opacity: 1, y: 0 }}

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -420,7 +420,7 @@ export const authAPI = {
     return response.json();
   },
 
-  searchUsers: async (query: string, limit = 10): Promise<UsersResponse> => {
+  searchUsers: async (query: string, limit = 10, signal?: AbortSignal): Promise<UsersResponse> => {
     const params = new URLSearchParams({
       q: query,
       limit: limit.toString(),
@@ -428,6 +428,8 @@ export const authAPI = {
 
     const response = await fetch(`${API_BASE_URL}/auth/search?${params}`, {
       headers: getAuthHeaders(),
+      cache: 'no-store',
+      signal,
     });
 
     if (!response.ok) {


### PR DESCRIPTION
Add a collection-aware Bloom filter to prefilter impossible member searches before querying MongoDB while preserving database verification for possible matches. Escape search input and enforce query length limits to prevent unsafe regex patterns.

Enable debounced live search after two characters, cancel stale requests, and retain immediate Enter and button-based search behavior.