### PR TITLE
feat: add isolated SQL injection sandbox challenge

### DIFF
--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -25,6 +25,7 @@
         "multer": "^2.1.1",
         "multer-s3": "^3.0.1",
         "nodemailer": "^8.0.5",
+        "pg-mem": "^3.0.14",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
         "serverless-http": "^3.2.0",
@@ -385,6 +386,8 @@
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
+    "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
+
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
@@ -404,6 +407,8 @@
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "concat-stream": ["concat-stream@2.0.0", "", { "dependencies": { "buffer-from": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.0.2", "typedarray": "^0.0.6" } }, "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A=="],
 
@@ -425,6 +430,8 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
@@ -432,6 +439,8 @@
     "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "discontinuous-range": ["discontinuous-range@1.0.0", "", {}, "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="],
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
@@ -533,6 +542,8 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "functional-red-black-tree": ["functional-red-black-tree@1.0.1", "", {}, "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
@@ -544,6 +555,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -567,6 +580,8 @@
 
     "ignore-by-default": ["ignore-by-default@1.0.1", "", {}, "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA=="],
 
+    "immutable": ["immutable@4.3.9", "", {}, "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ=="],
+
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
@@ -585,6 +600,8 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
+    "isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jose": ["jose@4.15.9", "", {}, "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="],
@@ -595,7 +612,11 @@
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
+    "json-stable-stringify": ["json-stable-stringify@1.3.0", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "isarray": "^2.0.5", "jsonify": "^0.0.1", "object-keys": "^1.1.1" } }, "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg=="],
+
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "jsonify": ["jsonify@0.0.1", "", {}, "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg=="],
 
     "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
 
@@ -659,11 +680,15 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
+    "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
+
     "mongodb": ["mongodb@5.9.2", "", { "dependencies": { "bson": "^5.5.0", "mongodb-connection-string-url": "^2.6.0", "socks": "^2.7.1" }, "optionalDependencies": { "@mongodb-js/saslprep": "^1.1.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.188.0", "@mongodb-js/zstd": "^1.0.0", "kerberos": "^1.0.0 || ^2.0.0", "mongodb-client-encryption": ">=2.3.0 <3", "snappy": "^7.2.2" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "kerberos", "mongodb-client-encryption", "snappy"] }, "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ=="],
 
     "mongodb-connection-string-url": ["mongodb-connection-string-url@2.6.0", "", { "dependencies": { "@types/whatwg-url": "^8.2.1", "whatwg-url": "^11.0.0" } }, "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ=="],
 
     "mongoose": ["mongoose@7.8.9", "", { "dependencies": { "bson": "^5.5.0", "kareem": "2.5.1", "mongodb": "5.9.2", "mpath": "0.9.0", "mquery": "5.0.0", "ms": "2.1.3", "sift": "16.0.1" } }, "sha512-V3GBAJbmOAdzEP8murOvlg7q1szlbe4jTBRyW+JBHRduJBe7F9dk5eyqJDTuYrdBcOOWfLbr6AgXrDK7F0/o5A=="],
+
+    "moo": ["moo@0.5.3", "", {}, "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA=="],
 
     "mpath": ["mpath@0.9.0", "", {}, "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew=="],
 
@@ -677,6 +702,8 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "nearley": ["nearley@2.20.1", "", { "dependencies": { "commander": "^2.19.0", "moo": "^0.5.0", "railroad-diagrams": "^1.0.0", "randexp": "0.4.6" }, "bin": { "nearleyc": "bin/nearleyc.js", "nearley-test": "bin/nearley-test.js", "nearley-unparse": "bin/nearley-unparse.js", "nearley-railroad": "bin/nearley-railroad.js" } }, "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ=="],
+
     "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "nodemailer": ["nodemailer@8.0.7", "", {}, "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow=="],
@@ -687,7 +714,11 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
+    "object-hash": ["object-hash@2.2.0", "", {}, "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="],
+
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
@@ -710,6 +741,10 @@
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-to-regexp": ["path-to-regexp@0.1.13", "", {}, "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="],
+
+    "pg-mem": ["pg-mem@3.0.14", "", { "dependencies": { "functional-red-black-tree": "^1.0.1", "immutable": "^4.3.4", "json-stable-stringify": "^1.0.1", "lru-cache": "^6.0.0", "moment": "^2.27.0", "object-hash": "^2.0.3", "pgsql-ast-parser": "^12.0.2" }, "peerDependencies": { "@mikro-orm/core": ">=4.5.3", "@mikro-orm/postgresql": ">=4.5.3", "knex": ">=0.20", "kysely": ">=0.26", "mikro-orm": "*", "pg-promise": ">=10.8.7", "pg-server": "^0.1.5", "postgres": "^3.4.4", "slonik": ">=23.0.1", "typeorm": ">=0.2.29" }, "optionalPeers": ["@mikro-orm/core", "@mikro-orm/postgresql", "knex", "kysely", "mikro-orm", "pg-promise", "pg-server", "postgres", "slonik", "typeorm"] }, "sha512-G9m8OD0A+YS083smidSUJddTX2dEDPT8mRMG3sQGNiGfS/mkvAgd9Kf1/onD5633bFN7HcQK/Tn2x7qjBMFRUQ=="],
+
+    "pgsql-ast-parser": ["pgsql-ast-parser@12.0.2", "", { "dependencies": { "moo": "^0.5.1", "nearley": "^2.19.5" } }, "sha512-1WWa96Sw6h4uv9GLw98EzH/+xoBTC8j2TwV/AMW3E+Ir/fHOu/jLLbj6kPiz3y2bGISTKNYvKWwHoqvQ5FLuAw=="],
 
     "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -741,6 +776,10 @@
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
+    "railroad-diagrams": ["railroad-diagrams@1.0.0", "", {}, "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="],
+
+    "randexp": ["randexp@0.4.6", "", { "dependencies": { "discontinuous-range": "1.0.0", "ret": "~0.1.10" } }, "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ=="],
+
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@2.5.3", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
@@ -750,6 +789,8 @@
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
+    "ret": ["ret@0.1.15", "", {}, "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
@@ -770,6 +811,8 @@
     "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "serverless-http": ["serverless-http@3.2.0", "", {}, "sha512-QvSyZXljRLIGqwcJ4xsKJXwkZnAVkse1OajepxfjkBXV0BMvRS5R546Z4kCBI8IygDzkQY0foNPC/rnipaE9pQ=="],
+
+    "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/src/server.js",
     "dev": "tsx watch src/server.ts",
     "typecheck": "tsc --noEmit",
-    "test": "echo \"error: no test specified.\" && exit 1",
+    "test": "bun test",
     "lint": "eslint .",
     "rebuild-sharp-lambda": "bun install --force --os=linux --cpu=x64",
     "cleanup-aws": "tsx scripts/cleanup-aws-credentials.ts",
@@ -17,6 +17,7 @@
     "seed-aws-cyber-challenge": "tsx scripts/seedAwsCyberChallenge.ts",
     "seed-robots-trap-challenge": "tsx scripts/challenges/seedRobotsTrapChallenge.ts",
     "seed-ciphered-seal-challenge": "tsx scripts/challenges/seedCipheredSealChallenge.ts",
+    "seed-sql-injection-challenge": "tsx scripts/challenges/seedSqlInjectionSandboxChallenge.ts",
     "migrate-challenge-catalog": "tsx scripts/challenges/migrateChallengeCatalogAssignments.ts"
   },
   "dependencies": {
@@ -40,6 +41,7 @@
     "multer": "^2.1.1",
     "multer-s3": "^3.0.1",
     "nodemailer": "^8.0.5",
+    "pg-mem": "^3.0.14",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "serverless-http": "^3.2.0",

--- a/backend/scripts/challenges/migrateChallengeCatalogAssignments.ts
+++ b/backend/scripts/challenges/migrateChallengeCatalogAssignments.ts
@@ -18,6 +18,7 @@ const curatedKeys = new Set([
   'aws_cloud_security_lab',
   'robots_txt_trap',
   'ciphered_seal_protocol',
+  'sql_injection_sandbox',
 ]);
 
 const toAssignmentStatus = (status: string): ChallengeAssignmentStatus => {

--- a/backend/scripts/challenges/seedSqlInjectionSandboxChallenge.ts
+++ b/backend/scripts/challenges/seedSqlInjectionSandboxChallenge.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env bun
+
+import mongoose from 'mongoose';
+
+import env from '../../src/config/env';
+import logger from '../../src/config/logger';
+import Challenge from '../../src/models/Challenge';
+import User from '../../src/models/User';
+
+const log = logger.child({ module: 'seedSqlInjectionSandboxChallenge' });
+const challengeKey = 'sql_injection_sandbox';
+
+async function seedSqlInjectionSandboxChallenge(): Promise<void> {
+  if (!env.MONGODB_URI) {
+    throw new Error('MONGODB_URI is required');
+  }
+
+  await mongoose.connect(env.MONGODB_URI);
+  log.info('connected to mongodb.');
+
+  const owner = await User.findOne({ role: { $in: ['superuser', 'admin'] }, status: 'active' })
+    .sort({ role: -1, createdAt: 1 })
+    .select('_id email role');
+
+  if (!owner) {
+    throw new Error('An active admin or superuser is required to seed the challenge.');
+  }
+
+  const challenge = await Challenge.findOneAndUpdate(
+    { key: challengeKey },
+    {
+      $set: {
+        key: challengeKey,
+        slug: 'sql-injection-sandbox',
+        title: 'SQL Injection Sandbox',
+        summary:
+          'Exploit an unsafe archive search query to recover a restricted record from an isolated database.',
+        description:
+          'A toy archive search interpolates input directly into SQL. Inspect the generated statement, alter its logic, and recover the personalized flag stored in a row that normal searches cannot return.',
+        instructions:
+          'Search the archive and inspect the SQL statement produced by the application. Determine how quoted input changes the WHERE clause. Recover the restricted record and submit its FLAG{...} value. The sandbox contains only synthetic data and accepts one SELECT statement at a time.',
+        source: 'curated',
+        status: 'published',
+        kind: 'single',
+        difficulty: 'medium',
+        estimatedMinutes: 15,
+        tags: ['sql', 'security', 'injection', 'web'],
+        publishedAt: new Date(),
+        startsAt: null,
+        endsAt: null,
+        rewardIntegrationInstanceId: null,
+        validation: {
+          type: 'sql_injection',
+          tableName: 'archive_records',
+          maxInputLength: 180,
+          maxRows: 20,
+          successMessage: 'Restricted record recovered. SQL injection challenge complete.',
+        },
+        reward: {
+          enabled: true,
+          bits: 50,
+          xpMode: 'custom',
+          xpAmount: 30,
+          activityName: 'SQL Injection Sandbox',
+          description: 'Completed SQL Injection Sandbox',
+          applyGroupMultipliers: true,
+          applyPersonalMultipliers: true,
+        },
+        updatedBy: owner._id,
+      },
+      $unset: {
+        maxAttempts: '',
+      },
+      $setOnInsert: {
+        version: 1,
+        assignmentMigrationVersion: 1,
+        createdBy: owner._id,
+      },
+    },
+    { new: true, upsert: true, setDefaultsOnInsert: true }
+  );
+
+  log.info(`seeded challenge ${challenge.title} (${challenge.slug}).`);
+  log.info(`owner: ${owner.email} (${owner.role}).`);
+}
+
+seedSqlInjectionSandboxChallenge()
+  .catch((error: unknown) => {
+    log.error('failed to seed SQL Injection Sandbox.', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await mongoose.disconnect();
+    log.info('disconnected from mongodb.');
+  });

--- a/backend/src/controllers/challengeController.ts
+++ b/backend/src/controllers/challengeController.ts
@@ -6,8 +6,10 @@ import {
   getCipheredSealRouteState,
   getChallengeProgress,
   getPublishedChallenge,
+  getSqlInjectionSandboxState,
   listPublishedChallenges,
   resolveCipheredSealRouteSeed,
+  searchSqlInjectionSandbox,
   startChallenge,
   submitChallenge,
 } from '../services/challengeService';
@@ -93,6 +95,38 @@ export const resolveCipheredSealSeed = async (req: Request, res: Response): Prom
     res
       .status(getErrorStatus(error, 400))
       .json(getErrorBody(error, 'Unable to resolve the seal values'));
+  }
+};
+
+export const getSqlInjectionSandbox = async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!req.user?.id) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    const result = await getSqlInjectionSandboxState(req.params.slug, req.user.id);
+    res.json(result);
+  } catch (error: unknown) {
+    res
+      .status(getErrorStatus(error, 404))
+      .json(getErrorBody(error, 'Unable to load SQL injection sandbox'));
+  }
+};
+
+export const searchSqlInjection = async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!req.user?.id) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    const result = await searchSqlInjectionSandbox(req.params.slug, req.user.id, req.body?.query);
+    res.json(result);
+  } catch (error: unknown) {
+    res
+      .status(getErrorStatus(error, 400))
+      .json(getErrorBody(error, 'Unable to run SQL sandbox query'));
   }
 };
 

--- a/backend/src/routes/challenges.ts
+++ b/backend/src/routes/challenges.ts
@@ -1,9 +1,20 @@
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 
 import * as challengeController from '../controllers/challengeController';
 import checkJwt, { optionalJwt } from '../middleware/auth';
 
 const router = express.Router();
+
+const sqlSandboxSearchLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
+  message: {
+    error: 'Too many sandbox queries. Wait a moment before trying again.',
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 router.get('/', optionalJwt, challengeController.listChallenges);
 router.get('/ciphered-seal/route/:routeKey', checkJwt, challengeController.getCipheredSealState);
@@ -11,6 +22,13 @@ router.post(
   '/ciphered-seal/route/:routeKey/resolve',
   checkJwt,
   challengeController.resolveCipheredSealSeed
+);
+router.get('/:slug/sql-sandbox', checkJwt, challengeController.getSqlInjectionSandbox);
+router.post(
+  '/:slug/sql-sandbox/search',
+  checkJwt,
+  sqlSandboxSearchLimiter,
+  challengeController.searchSqlInjection
 );
 router.get('/:slug', optionalJwt, challengeController.getChallenge);
 router.get('/:slug/progress', checkJwt, challengeController.getProgress);

--- a/backend/src/services/challengeService.ts
+++ b/backend/src/services/challengeService.ts
@@ -38,6 +38,11 @@ import {
   resolveSubmittedCipheredSealSeed,
 } from './cipheredSealService';
 import { getPrizeversityStatus } from './rewardIntegrationService';
+import {
+  getSqlInjectionPublicExperience,
+  runSqlInjectionSandboxQuery,
+  SQL_INJECTION_VALIDATOR_TYPE,
+} from './sqlInjectionSandboxService';
 
 export type ChallengeErrorCode =
   | 'CHALLENGE_NOT_FOUND'
@@ -340,10 +345,14 @@ const toRewardPreview = (reward: IChallengeRewardConfig) => ({
 });
 
 const getPublicChallengeExperience = (challenge: IChallengeDocument) => {
-  if (getValidatorType(challenge) !== CIPHERED_SEAL_VALIDATOR_TYPE) return undefined;
-
   try {
-    return getCipheredSealPublicExperience(challenge.validation);
+    if (getValidatorType(challenge) === CIPHERED_SEAL_VALIDATOR_TYPE) {
+      return getCipheredSealPublicExperience(challenge.validation);
+    }
+    if (getValidatorType(challenge) === SQL_INJECTION_VALIDATOR_TYPE) {
+      return getSqlInjectionPublicExperience(challenge.validation);
+    }
+    return undefined;
   } catch {
     return undefined;
   }
@@ -835,6 +844,50 @@ export const resolveCipheredSealRouteSeed = async (
 ) => {
   const { challenge, user } = await getCipheredSealPlayerContext(routeKey, userId);
   return resolveSubmittedCipheredSealSeed(challenge, user, seedNumber);
+};
+
+const getSqlInjectionPlayerContext = async (slug: string, userId: string) => {
+  const { challenge, assignment, user } = await ensureAssignedChallenge(slug, userId);
+  if (getValidatorType(challenge) !== SQL_INJECTION_VALIDATOR_TYPE) {
+    throw new ChallengeServiceError('SQL sandbox not found.', 'CHALLENGE_NOT_FOUND', 404);
+  }
+  if (assignment.reward?.enabled && !hasRewardIdentity(user)) {
+    throw new ChallengeServiceError(
+      'Link your Prizeversity account before entering this challenge.',
+      'REWARD_LINK_REQUIRED',
+      403
+    );
+  }
+
+  const progress = await getOrCreateProgress(challenge, assignment, userId);
+  return { challenge, assignment, user, progress };
+};
+
+export const getSqlInjectionSandboxState = async (slug: string, userId: string) => {
+  const { challenge, assignment, progress } = await getSqlInjectionPlayerContext(slug, userId);
+  return {
+    challenge: toPublicChallengeDto(challenge, assignment),
+    progress: toProgressDto(progress),
+    rewardLink: await getRewardLinkSummary(userId, getAssignmentScopeId(assignment)),
+    sandbox: getSqlInjectionPublicExperience(challenge.validation),
+  };
+};
+
+export const searchSqlInjectionSandbox = async (slug: string, userId: string, input: unknown) => {
+  const { challenge, user, progress } = await getSqlInjectionPlayerContext(slug, userId);
+  try {
+    return runSqlInjectionSandboxQuery(challenge.validation, input, {
+      challenge,
+      progress,
+      user,
+    });
+  } catch (error: unknown) {
+    throw new ChallengeServiceError(
+      error instanceof Error ? error.message : 'Unable to run the sandbox query.',
+      'INVALID_CHALLENGE_INPUT',
+      400
+    );
+  }
 };
 
 export const submitChallenge = async (

--- a/backend/src/services/challengeValidatorService.ts
+++ b/backend/src/services/challengeValidatorService.ts
@@ -11,6 +11,12 @@ import {
   isCipheredSealSequence,
   normalizeCipheredSealConfig,
 } from './cipheredSealService';
+import {
+  getSqlInjectionSuccessMessage,
+  normalizeSqlInjectionSandboxConfig,
+  SQL_INJECTION_VALIDATOR_TYPE,
+  validateSqlInjectionCompletionToken,
+} from './sqlInjectionSandboxService';
 
 export interface ChallengeValidatorContext {
   user: IUserDocument;
@@ -86,6 +92,12 @@ interface GenericProofSubmissionPayload {
   text?: string;
   link?: string;
   url?: string;
+}
+
+interface SqlInjectionSubmissionPayload {
+  flag?: string;
+  secret?: string;
+  answer?: string;
 }
 
 const validators = new Map<string, ChallengeValidator>();
@@ -209,6 +221,15 @@ const normalizeGenericProofPayload = (payload: unknown): GenericProofSubmissionP
     text: cleanString(payload.text) || undefined,
     link: cleanString(payload.link) || undefined,
     url: cleanString(payload.url) || undefined,
+  };
+};
+
+const normalizeSqlInjectionPayload = (payload: unknown): SqlInjectionSubmissionPayload => {
+  if (!isRecord(payload)) return {};
+  return {
+    flag: cleanString(payload.flag) || undefined,
+    secret: cleanString(payload.secret) || undefined,
+    answer: cleanString(payload.answer) || undefined,
   };
 };
 
@@ -486,6 +507,50 @@ const cipheredSealValidator: ChallengeValidator = {
   },
 };
 
+const sqlInjectionValidator: ChallengeValidator = {
+  type: SQL_INJECTION_VALIDATOR_TYPE,
+
+  async validate(rawConfig, rawPayload, context) {
+    normalizeSqlInjectionSandboxConfig(rawConfig);
+    const payload = normalizeSqlInjectionPayload(rawPayload);
+    const submittedToken = cleanString(payload.flag || payload.secret || payload.answer);
+
+    if (!submittedToken) {
+      return {
+        accepted: false,
+        outcome: 'rejected',
+        message: 'Submit the flag recovered from the restricted database row.',
+      };
+    }
+
+    const accepted = validateSqlInjectionCompletionToken(submittedToken, context);
+    return {
+      accepted,
+      outcome: accepted ? 'accepted' : 'rejected',
+      message: accepted
+        ? getSqlInjectionSuccessMessage(rawConfig)
+        : 'That flag does not belong to this challenge session.',
+      publicDetails: {
+        isolatedSandbox: true,
+      },
+      privateDetails: {
+        personalizedToken: true,
+        challengeVersion: context.challenge.version,
+      },
+    };
+  },
+
+  sanitizePayload(payload) {
+    const normalizedPayload = normalizeSqlInjectionPayload(payload);
+    return {
+      submitted: Boolean(
+        normalizedPayload.flag || normalizedPayload.secret || normalizedPayload.answer
+      ),
+      flag: '[redacted]',
+    };
+  },
+};
+
 export const registerChallengeValidator = (validator: ChallengeValidator): void => {
   validators.set(validator.type, validator);
 };
@@ -581,6 +646,10 @@ export const prepareChallengeValidationConfigForStorage = (
     return { ...getCipheredSealConfig({ ...config, type }) };
   }
 
+  if (type === SQL_INJECTION_VALIDATOR_TYPE) {
+    return { ...normalizeSqlInjectionSandboxConfig({ ...config, type }) };
+  }
+
   getChallengeValidator(type);
   return {
     ...config,
@@ -592,3 +661,4 @@ registerChallengeValidator(awsSecretValidator);
 registerChallengeValidator(staticSecretValidator);
 registerChallengeValidator(manualReviewValidator);
 registerChallengeValidator(cipheredSealValidator);
+registerChallengeValidator(sqlInjectionValidator);

--- a/backend/src/services/sqlInjectionSandboxService.ts
+++ b/backend/src/services/sqlInjectionSandboxService.ts
@@ -1,0 +1,236 @@
+import crypto from 'crypto';
+import { newDb } from 'pg-mem';
+
+import env from '../config/env';
+import type { IChallengeDocument } from '../models/Challenge';
+import type { IChallengeProgressDocument } from '../models/ChallengeProgress';
+import type { IUserDocument } from '../models/User';
+
+export const SQL_INJECTION_VALIDATOR_TYPE = 'sql_injection' as const;
+
+const DEFAULT_TABLE_NAME = 'archive_records';
+const DEFAULT_MAX_INPUT_LENGTH = 180;
+const DEFAULT_MAX_ROWS = 20;
+const MAX_CONFIGURED_ROWS = 50;
+
+export interface SqlInjectionSandboxConfig {
+  type: typeof SQL_INJECTION_VALIDATOR_TYPE;
+  tableName: string;
+  maxInputLength: number;
+  maxRows: number;
+  successMessage?: string;
+}
+
+export interface SqlInjectionSandboxContext {
+  challenge: IChallengeDocument;
+  progress: IChallengeProgressDocument;
+  user: IUserDocument;
+}
+
+export interface SqlInjectionSandboxRow {
+  id: number;
+  title: string;
+  department: string;
+  classification: string;
+  content: string;
+}
+
+export interface SqlInjectionSandboxSearchResult {
+  statement: string;
+  rows: SqlInjectionSandboxRow[];
+  rowCount: number;
+  truncated: boolean;
+  queryError?: string;
+}
+
+const cleanString = (value: unknown): string => {
+  return typeof value === 'string' ? value.trim() : '';
+};
+
+const normalizeBoundedInteger = (
+  value: unknown,
+  fallback: number,
+  minimum: number,
+  maximum: number
+): number => {
+  const numericValue = Number(value);
+  return Number.isInteger(numericValue) && numericValue >= minimum && numericValue <= maximum
+    ? numericValue
+    : fallback;
+};
+
+export const normalizeSqlInjectionSandboxConfig = (
+  rawConfig: Record<string, unknown>
+): SqlInjectionSandboxConfig => {
+  if (rawConfig.type !== SQL_INJECTION_VALIDATOR_TYPE) {
+    throw new Error('Invalid SQL injection sandbox validator config type.');
+  }
+
+  const tableName = cleanString(rawConfig.tableName) || DEFAULT_TABLE_NAME;
+  if (!/^[a-z][a-z0-9_]{2,47}$/.test(tableName)) {
+    throw new Error(
+      'SQL injection sandbox tableName must be a lowercase SQL identifier between 3 and 48 characters.'
+    );
+  }
+
+  return {
+    type: SQL_INJECTION_VALIDATOR_TYPE,
+    tableName,
+    maxInputLength: normalizeBoundedInteger(
+      rawConfig.maxInputLength,
+      DEFAULT_MAX_INPUT_LENGTH,
+      40,
+      500
+    ),
+    maxRows: normalizeBoundedInteger(rawConfig.maxRows, DEFAULT_MAX_ROWS, 1, MAX_CONFIGURED_ROWS),
+    successMessage: cleanString(rawConfig.successMessage) || undefined,
+  };
+};
+
+const getSigningSecret = (): string => {
+  const secret = env.CHALLENGE_SIGNING_SECRET || env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('Challenge signing secret is not configured.');
+  }
+  return secret;
+};
+
+export const buildSqlInjectionCompletionToken = (context: SqlInjectionSandboxContext): string => {
+  const digest = crypto
+    .createHmac('sha256', getSigningSecret())
+    .update(
+      [
+        'sql-injection-sandbox',
+        String(context.challenge._id),
+        String(context.challenge.version),
+        String(context.progress.assignmentId),
+        String(context.user._id),
+      ].join(':')
+    )
+    .digest('hex')
+    .slice(0, 24);
+
+  return `FLAG{${digest}}`;
+};
+
+const compareTokens = (submitted: string, expected: string): boolean => {
+  const submittedBuffer = Buffer.from(submitted);
+  const expectedBuffer = Buffer.from(expected);
+  return (
+    submittedBuffer.length === expectedBuffer.length &&
+    crypto.timingSafeEqual(submittedBuffer, expectedBuffer)
+  );
+};
+
+export const validateSqlInjectionCompletionToken = (
+  submittedToken: string,
+  context: SqlInjectionSandboxContext
+): boolean => {
+  return compareTokens(submittedToken.trim(), buildSqlInjectionCompletionToken(context));
+};
+
+const escapeSqlLiteral = (value: string): string => value.replace(/'/g, "''");
+
+const createSandboxDatabase = (tableName: string, completionToken: string) => {
+  const database = newDb({ autoCreateForeignKeyIndices: false });
+  database.public.none(`
+    CREATE TABLE ${tableName} (
+      id INTEGER PRIMARY KEY,
+      title TEXT NOT NULL,
+      department TEXT NOT NULL,
+      classification TEXT NOT NULL,
+      content TEXT NOT NULL,
+      published BOOLEAN NOT NULL DEFAULT TRUE
+    );
+
+    INSERT INTO ${tableName} (id, title, department, classification, content, published) VALUES
+      (101, 'Cloud orientation schedule', 'Student Programs', 'PUBLIC', 'Tuesday sessions begin at 5:30 PM.', TRUE),
+      (204, 'Lambda workshop notes', 'Engineering', 'PUBLIC', 'Bring a laptop with the AWS CLI installed.', TRUE),
+      (318, 'Certification study group', 'Education', 'PUBLIC', 'Practice exams open after the kickoff meeting.', TRUE),
+      (427, 'Infrastructure office hours', 'Operations', 'PUBLIC', 'Questions are accepted in the weekly lab.', TRUE),
+      (9001, 'Internal access ledger', 'Security', 'RESTRICTED', '${escapeSqlLiteral(
+        completionToken
+      )}', FALSE);
+  `);
+  return database;
+};
+
+const validateSearchInput = (input: unknown, config: SqlInjectionSandboxConfig): string => {
+  if (typeof input !== 'string' || input.length === 0) {
+    throw new Error('Enter a search term or SQL payload.');
+  }
+  if (input.length > config.maxInputLength) {
+    throw new Error(`Search input must be ${config.maxInputLength} characters or fewer.`);
+  }
+  const hasControlCharacter = Array.from(input).some((character) => {
+    const codePoint = character.codePointAt(0) || 0;
+    return codePoint <= 31 || codePoint === 127;
+  });
+  if (hasControlCharacter) {
+    throw new Error('Search input cannot contain control characters.');
+  }
+  if (input.includes(';')) {
+    throw new Error('Stacked SQL statements are disabled in this sandbox.');
+  }
+  return input;
+};
+
+const isSandboxRow = (value: unknown): value is SqlInjectionSandboxRow => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const row = value as Record<string, unknown>;
+  return (
+    typeof row.id === 'number' &&
+    typeof row.title === 'string' &&
+    typeof row.department === 'string' &&
+    typeof row.classification === 'string' &&
+    typeof row.content === 'string'
+  );
+};
+
+export const runSqlInjectionSandboxQuery = (
+  rawConfig: Record<string, unknown>,
+  rawInput: unknown,
+  context: SqlInjectionSandboxContext
+): SqlInjectionSandboxSearchResult => {
+  const config = normalizeSqlInjectionSandboxConfig(rawConfig);
+  const input = validateSearchInput(rawInput, config);
+  const completionToken = buildSqlInjectionCompletionToken(context);
+  const database = createSandboxDatabase(config.tableName, completionToken);
+  const statement = `SELECT id, title, department, classification, content FROM ${config.tableName} WHERE title ILIKE '%${input}%' AND published = TRUE ORDER BY id`;
+
+  try {
+    const result = database.public.query(statement);
+    const allRows = result.rows.filter(isSandboxRow);
+    const rows = allRows.slice(0, config.maxRows);
+    return {
+      statement,
+      rows,
+      rowCount: rows.length,
+      truncated: allRows.length > rows.length,
+    };
+  } catch {
+    return {
+      statement,
+      rows: [],
+      rowCount: 0,
+      truncated: false,
+      queryError: 'The database rejected that statement. Check its quoting and comment syntax.',
+    };
+  }
+};
+
+export const getSqlInjectionPublicExperience = (rawConfig: Record<string, unknown>) => {
+  const config = normalizeSqlInjectionSandboxConfig(rawConfig);
+  return {
+    type: SQL_INJECTION_VALIDATOR_TYPE,
+    tableName: config.tableName,
+    maxInputLength: config.maxInputLength,
+  };
+};
+
+export const getSqlInjectionSuccessMessage = (rawConfig: Record<string, unknown>): string => {
+  return (
+    normalizeSqlInjectionSandboxConfig(rawConfig).successMessage ||
+    'Restricted record recovered. SQL injection challenge complete.'
+  );
+};

--- a/backend/tests/sqlInjectionSandboxService.test.ts
+++ b/backend/tests/sqlInjectionSandboxService.test.ts
@@ -1,0 +1,63 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+
+import env from '../src/config/env';
+import type { IChallengeDocument } from '../src/models/Challenge';
+import type { IChallengeProgressDocument } from '../src/models/ChallengeProgress';
+import type { IUserDocument } from '../src/models/User';
+import {
+  buildSqlInjectionCompletionToken,
+  runSqlInjectionSandboxQuery,
+  SqlInjectionSandboxContext,
+  validateSqlInjectionCompletionToken,
+} from '../src/services/sqlInjectionSandboxService';
+
+const config = {
+  type: 'sql_injection',
+  tableName: 'archive_records',
+  maxInputLength: 180,
+  maxRows: 20,
+};
+
+const createContext = (userId: string): SqlInjectionSandboxContext => ({
+  challenge: { _id: 'challenge-1', version: 3 } as unknown as IChallengeDocument,
+  progress: { assignmentId: 'assignment-1' } as unknown as IChallengeProgressDocument,
+  user: { _id: userId } as unknown as IUserDocument,
+});
+
+beforeAll(() => {
+  (env as { CHALLENGE_SIGNING_SECRET?: string }).CHALLENGE_SIGNING_SECRET =
+    'sql-sandbox-test-signing-secret';
+});
+
+describe('SQL injection sandbox', () => {
+  it('keeps the restricted row out of ordinary searches', () => {
+    const result = runSqlInjectionSandboxQuery(config, 'Cloud', createContext('user-1'));
+
+    expect(result.queryError).toBeUndefined();
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].classification).toBe('PUBLIC');
+    expect(result.rows.some((row) => row.content.startsWith('FLAG{'))).toBe(false);
+  });
+
+  it('allows the intended boolean injection to recover the personalized flag', () => {
+    const context = createContext('user-1');
+    const result = runSqlInjectionSandboxQuery(config, "' OR 1=1 --", context);
+    const restrictedRow = result.rows.find((row) => row.classification === 'RESTRICTED');
+
+    expect(result.queryError).toBeUndefined();
+    expect(restrictedRow?.content).toBe(buildSqlInjectionCompletionToken(context));
+    expect(validateSqlInjectionCompletionToken(restrictedRow?.content || '', context)).toBe(true);
+  });
+
+  it('derives different flags for different students', () => {
+    expect(buildSqlInjectionCompletionToken(createContext('user-1'))).not.toBe(
+      buildSqlInjectionCompletionToken(createContext('user-2'))
+    );
+  });
+
+  it('rejects stacked statements', () => {
+    expect(() =>
+      runSqlInjectionSandboxQuery(config, "'; DROP TABLE archive_records; --", createContext('u'))
+    ).toThrow('Stacked SQL statements are disabled');
+  });
+});

--- a/docs-site/authoring/curated-challenges.md
+++ b/docs-site/authoring/curated-challenges.md
@@ -39,8 +39,26 @@ Run seed scripts separately for each environment whose catalog should contain th
 | AWS Cloud Security Lab | `aws_secret`      | Uses the authenticated user's assigned AWS challenge secret.                           |
 | Robots.txt Trap        | `static_secret`   | Adds `/robots.txt` discovery and a dedicated hidden vault route.                       |
 | Ciphered Seal Protocol | `ciphered_seal`   | Adds a metadata route key, per-user layout, calculator state, and sequence validation. |
+| SQL Injection Sandbox  | `sql_injection`   | Runs vulnerable queries against a disposable, synthetic in-memory database.            |
 
 The Robots.txt challenge demonstrates that a curated experience may reuse a generic validator while still requiring source-controlled routes and presentation.
+
+## SQL Injection Sandbox
+
+The SQL Injection Sandbox is intentionally vulnerable within a narrow boundary. Each search request creates a fresh in-memory PostgreSQL-compatible database containing only synthetic records. The vulnerable query never touches MongoDB, Prizeversity, application users, environment variables, or another student's state.
+
+The restricted row contains a completion flag derived with an HMAC over the challenge, challenge version, classroom assignment, and AWS Student Hub user. Consequently, a flag copied from another student or another assignment is rejected by the standard challenge submission endpoint.
+
+Operational behavior:
+
+- Opening the lab enforces authentication, active Prizeversity linking, and an active assignment.
+- Search requests are rate-limited, length-limited, and restricted to one statement; semicolons are rejected.
+- SQL parser errors are converted to a generic student-safe message.
+- Search activity does not consume challenge attempts. Only final flag submissions do.
+- Correct submission uses the normal completion and reward-emission pipeline.
+- The database is rebuilt for every query and retains no student input.
+
+This controlled vulnerability must remain in `sqlInjectionSandboxService.ts`. Do not point its query executor at a persistent or shared database to make the data feel more realistic.
 
 ## Implementing a curated validator
 

--- a/docs-site/reference/deployment.md
+++ b/docs-site/reference/deployment.md
@@ -62,6 +62,7 @@ cd backend
 bun run seed-aws-cyber-challenge
 bun run seed-robots-trap-challenge
 bun run seed-ciphered-seal-challenge
+bun run seed-sql-injection-challenge
 ```
 
 Each command uses the active `MONGODB_URI`. Confirm the target before running it.

--- a/docs-site/reference/http-api.md
+++ b/docs-site/reference/http-api.md
@@ -98,6 +98,33 @@ POST /challenges/ciphered-seal/route/:routeKey/resolve
 
 The resolve body contains `seedNumber`. Both endpoints enforce linked instance and active assignment scope.
 
+### SQL Injection Sandbox routes
+
+```text
+GET  /challenges/:slug/sql-sandbox
+POST /challenges/:slug/sql-sandbox/search
+```
+
+The state route starts or resumes assignment-scoped progress and returns public sandbox metadata. The search body is:
+
+```json
+{
+  "query": "archive title or SQL payload"
+}
+```
+
+The response contains the executed synthetic statement, bounded result rows, truncation state, and an optional safe parser error. Search calls are rate-limited and do not increment completion attempts. Students submit a recovered flag through the standard endpoint:
+
+```json
+{
+  "payload": {
+    "flag": "FLAG{personalized-value}"
+  }
+}
+```
+
+Both sandbox routes enforce authentication, active account linking, published definition state, and the student's active classroom assignment.
+
 ## Admin catalog routes
 
 | Method   | Path                                             | Purpose                                                                               |

--- a/docs-site/reference/security.md
+++ b/docs-site/reference/security.md
@@ -58,6 +58,20 @@ The generic sanitizer redacts field names containing secret, password, token, or
 
 For `static_secret`, plaintext expected values are normalized and hashed before the definition is stored. Student submissions are compared as hashes. This protects the database record from casually exposing the answer, but it does not compensate for weak or guessable secrets.
 
+## Deliberately vulnerable labs
+
+The SQL Injection Sandbox is vulnerable by design, but its SQL boundary is disposable and synthetic:
+
+- A new in-memory database is created for every search request.
+- The database contains no application, Prizeversity, credential, or student-profile data.
+- The vulnerable query cannot reach MongoDB or any persistent SQL service.
+- Stacked statements and control characters are rejected, input and output are bounded, and requests are rate-limited.
+- Parser details and stacks are not returned to the student.
+- The hidden flag is HMAC-derived for one user, assignment, challenge, and version.
+- Final acceptance is performed by the backend validator using a timing-safe comparison.
+
+Do not replace the in-memory adapter with a production database connection. Extending this challenge with persistent data or general-purpose SQL execution changes the security model and requires a separate isolation review.
+
 ## Browser trust boundary
 
 The frontend is an untrusted presentation layer. A student can inspect JavaScript, network responses, hidden DOM, and public assets.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import QuickSetup from './pages/QuickSetup';
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import VaultTrap from './challenges/robotsTxtTrap/VaultTrap';
 import CipheredSealProtocol from './challenges/cipheredSeal/CipheredSealProtocol';
+import SqlInjectionSandbox from './challenges/sqlInjection/SqlInjectionSandbox';
 import './App.css';
 import './styles/VisualRefresh.css';
 
@@ -44,6 +45,7 @@ function AppContent() {
           <Route path="/resources" element={<Resources />} />
           <Route path="/events" element={<Events theme={theme} />} />
           <Route path="/challenges" element={<Challenges theme={theme} />} />
+          <Route path="/challenges/:slug/lab" element={<SqlInjectionSandbox />} />
           <Route path="/challenges/:slug" element={<ChallengeDetail theme={theme} />} />
           <Route path="/challenge/:routeKey" element={<CipheredSealProtocol />} />
           <Route path="/auth" element={<Auth theme={theme} />} />

--- a/frontend/src/challenges/sqlInjection/SqlInjectionSandbox.css
+++ b/frontend/src/challenges/sqlInjection/SqlInjectionSandbox.css
@@ -1,0 +1,701 @@
+.sql-lab-page {
+  --sql-ink: #15211d;
+  --sql-muted: #66706b;
+  --sql-panel: rgba(255, 255, 255, 0.96);
+  --sql-soft: #f3f5f2;
+  --sql-line: #dfe4df;
+  --sql-accent: #f39a27;
+  --sql-accent-dark: #9a5b0d;
+  --sql-terminal: #111915;
+  min-height: calc(100vh - 72px);
+  padding: clamp(1.5rem, 4vw, 4rem);
+  color: var(--sql-ink);
+  background:
+    radial-gradient(circle at 12% 10%, rgba(243, 154, 39, 0.12), transparent 27rem),
+    linear-gradient(rgba(37, 53, 46, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(37, 53, 46, 0.045) 1px, transparent 1px), #f5f7f5;
+  background-size:
+    auto,
+    32px 32px,
+    32px 32px,
+    auto;
+}
+
+[data-theme='dark'] .sql-lab-page {
+  --sql-ink: #eef3ef;
+  --sql-muted: #a5afa9;
+  --sql-panel: rgba(20, 27, 23, 0.97);
+  --sql-soft: #1b2420;
+  --sql-line: #344039;
+  --sql-terminal: #080d0a;
+  background:
+    radial-gradient(circle at 12% 10%, rgba(243, 154, 39, 0.11), transparent 27rem),
+    linear-gradient(rgba(216, 226, 219, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(216, 226, 219, 0.035) 1px, transparent 1px), #0f1512;
+  background-size:
+    auto,
+    32px 32px,
+    32px 32px,
+    auto;
+}
+
+.sql-lab-shell {
+  width: min(1440px, 100%);
+  margin: 0 auto;
+}
+
+.sql-lab-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  border: 1px solid var(--sql-line);
+  border-radius: 22px 22px 8px 8px;
+  background: var(--sql-panel);
+  box-shadow: 0 24px 70px rgba(18, 28, 23, 0.1);
+}
+
+.sql-lab-header-copy {
+  max-width: 850px;
+}
+
+.sql-lab-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 1.7rem;
+  color: var(--sql-muted);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.sql-lab-back-link:hover {
+  color: var(--sql-accent);
+}
+
+.sql-lab-kicker,
+.sql-panel-heading span,
+.sql-mission-card > span,
+.sql-flag-card > span {
+  display: block;
+  color: var(--sql-accent-dark);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+[data-theme='dark'] .sql-lab-kicker,
+[data-theme='dark'] .sql-panel-heading span,
+[data-theme='dark'] .sql-mission-card > span,
+[data-theme='dark'] .sql-flag-card > span {
+  color: #f6a943;
+}
+
+.sql-lab-header h1 {
+  margin: 0.45rem 0 0.65rem;
+  color: var(--sql-ink);
+  font-size: clamp(2rem, 4vw, 4.3rem);
+  font-weight: 500;
+  line-height: 0.98;
+  letter-spacing: -0.04em;
+}
+
+.sql-lab-header p {
+  max-width: 760px;
+  margin: 0;
+  color: var(--sql-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.sql-lab-status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 180px;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(243, 154, 39, 0.35);
+  border-radius: 14px;
+  color: var(--sql-accent-dark);
+  background: rgba(243, 154, 39, 0.09);
+}
+
+.sql-lab-status.complete {
+  color: #307748;
+  border-color: rgba(59, 154, 88, 0.35);
+  background: rgba(59, 154, 88, 0.1);
+}
+
+.sql-lab-status div,
+.sql-lab-status span,
+.sql-lab-status small {
+  display: block;
+}
+
+.sql-lab-status span {
+  font-weight: 700;
+}
+
+.sql-lab-status small {
+  margin-top: 0.15rem;
+  color: var(--sql-muted);
+  font-size: 0.72rem;
+}
+
+.sql-lab-alert {
+  margin-top: 1rem;
+  padding: 0.9rem 1.1rem;
+  border-radius: 10px;
+  font-size: 0.9rem;
+}
+
+.sql-lab-alert.error {
+  color: #9e302b;
+  border: 1px solid rgba(197, 68, 59, 0.3);
+  background: rgba(197, 68, 59, 0.09);
+}
+
+.sql-lab-alert.success {
+  color: #2f7848;
+  border: 1px solid rgba(59, 154, 88, 0.3);
+  background: rgba(59, 154, 88, 0.09);
+}
+
+.sql-lab-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.sql-query-console,
+.sql-mission-card,
+.sql-flag-card {
+  border: 1px solid var(--sql-line);
+  background: var(--sql-panel);
+  box-shadow: 0 18px 50px rgba(18, 28, 23, 0.07);
+}
+
+.sql-query-console {
+  min-width: 0;
+  padding: clamp(1.25rem, 2.5vw, 2rem);
+  border-radius: 8px 8px 8px 22px;
+}
+
+.sql-panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.sql-panel-heading h2,
+.sql-mission-card h2,
+.sql-flag-card h2 {
+  margin: 0.3rem 0 0;
+  color: var(--sql-ink);
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.sql-search-form label,
+.sql-flag-card label {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: var(--sql-ink);
+  font-size: 0.82rem;
+  font-weight: 650;
+}
+
+.sql-search-form > div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.65rem;
+}
+
+.sql-search-form input,
+.sql-flag-card input {
+  width: 100%;
+  min-width: 0;
+  padding: 0.85rem 0.95rem;
+  color: var(--sql-ink);
+  border: 1px solid var(--sql-line);
+  border-radius: 9px;
+  outline: none;
+  background: var(--sql-soft);
+  font: inherit;
+}
+
+.sql-search-form input:focus,
+.sql-flag-card input:focus {
+  border-color: var(--sql-accent);
+  box-shadow: 0 0 0 3px rgba(243, 154, 39, 0.13);
+}
+
+.sql-search-form button,
+.sql-flag-card button,
+.sql-reward-modal > button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-height: 44px;
+  padding: 0.7rem 1rem;
+  color: #171a18;
+  border: 1px solid #f3a13a;
+  border-radius: 9px;
+  background: #f3a13a;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.sql-search-form button:hover,
+.sql-flag-card button:hover,
+.sql-reward-modal > button:hover {
+  background: #ffad45;
+}
+
+.sql-search-form button:disabled,
+.sql-flag-card button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.sql-search-form small,
+.sql-flag-card form > small {
+  display: block;
+  margin-top: 0.55rem;
+  color: var(--sql-muted);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.sql-statement-viewer {
+  margin-top: 1.35rem;
+  padding: 1rem;
+  overflow: hidden;
+  color: #dfece4;
+  border: 1px solid #2e3a33;
+  border-radius: 10px;
+  background: var(--sql-terminal);
+}
+
+.sql-statement-viewer > div {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 0.7rem;
+  color: #8fa297;
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.sql-statement-viewer code {
+  display: block;
+  overflow-x: auto;
+  color: #f1c17c;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+  font-size: 0.82rem;
+  line-height: 1.65;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.sql-results-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 1.5rem 0 0.65rem;
+  color: var(--sql-muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.sql-results-heading strong {
+  color: var(--sql-ink);
+  font-size: 0.75rem;
+}
+
+.sql-results-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--sql-line);
+  border-radius: 10px;
+}
+
+.sql-results-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+
+.sql-results-table th,
+.sql-results-table td {
+  padding: 0.8rem;
+  border-bottom: 1px solid var(--sql-line);
+  text-align: left;
+  vertical-align: top;
+}
+
+.sql-results-table th {
+  color: var(--sql-muted);
+  background: var(--sql-soft);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.sql-results-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.sql-results-table tr.restricted {
+  background: rgba(243, 154, 39, 0.09);
+}
+
+.sql-results-table td > span {
+  display: inline-block;
+  padding: 0.18rem 0.4rem;
+  border: 1px solid var(--sql-line);
+  border-radius: 4px;
+  font-size: 0.65rem;
+  font-weight: 700;
+}
+
+.sql-result-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.4rem;
+  min-width: 190px;
+}
+
+.sql-result-content code {
+  color: var(--sql-ink);
+  overflow-wrap: anywhere;
+}
+
+.sql-result-content button {
+  display: inline-grid;
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  color: var(--sql-accent-dark);
+  border: 1px solid var(--sql-line);
+  border-radius: 6px;
+  background: var(--sql-panel);
+  cursor: pointer;
+}
+
+.sql-results-empty,
+.sql-query-error {
+  padding: 1.5rem;
+  color: var(--sql-muted);
+  border: 1px dashed var(--sql-line);
+  border-radius: 10px;
+  text-align: center;
+  font-size: 0.85rem;
+}
+
+.sql-query-error {
+  color: #a13a32;
+  border-style: solid;
+  border-color: rgba(197, 68, 59, 0.28);
+  background: rgba(197, 68, 59, 0.08);
+}
+
+.sql-results-truncated {
+  display: block;
+  padding: 0.6rem 0.8rem;
+  color: var(--sql-muted);
+}
+
+.sql-lab-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sql-mission-card,
+.sql-flag-card {
+  padding: 1.4rem;
+  border-radius: 8px;
+}
+
+.sql-mission-card p {
+  margin: 0.9rem 0 1.2rem;
+  color: var(--sql-muted);
+  font-size: 0.88rem;
+  line-height: 1.65;
+}
+
+.sql-mission-card dl {
+  margin: 0;
+}
+
+.sql-mission-card dl > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.7rem 0;
+  border-top: 1px solid var(--sql-line);
+}
+
+.sql-mission-card dt {
+  color: var(--sql-muted);
+  font-size: 0.75rem;
+}
+
+.sql-mission-card dd {
+  margin: 0;
+  color: var(--sql-ink);
+  font-size: 0.78rem;
+  font-weight: 650;
+  text-align: right;
+}
+
+.sql-flag-card form {
+  margin-top: 1rem;
+}
+
+.sql-flag-card form > button {
+  width: 100%;
+  margin-top: 0.7rem;
+}
+
+.sql-completed-state {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  padding: 1rem;
+  color: #347a4a;
+  border: 1px solid rgba(59, 154, 88, 0.3);
+  border-radius: 10px;
+  background: rgba(59, 154, 88, 0.08);
+}
+
+.sql-completed-state p {
+  margin: 0;
+  color: var(--sql-muted);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.sql-lab-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.7rem;
+  color: var(--sql-muted);
+}
+
+.sql-lab-loading svg {
+  animation: sql-spin 1s linear infinite;
+}
+
+.sql-lab-failure {
+  width: min(560px, 100%);
+  margin: 10vh auto;
+  padding: 2rem;
+  color: var(--sql-ink);
+  border: 1px solid var(--sql-line);
+  border-radius: 16px;
+  background: var(--sql-panel);
+}
+
+.sql-lab-failure > span {
+  display: block;
+  margin-top: 1rem;
+  color: var(--sql-accent-dark);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.sql-lab-failure h1 {
+  margin: 0.4rem 0;
+}
+
+.sql-lab-failure p {
+  color: var(--sql-muted);
+}
+
+.sql-lab-failure a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--sql-accent-dark);
+}
+
+.sql-reward-overlay {
+  position: fixed;
+  z-index: 1000;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  background: rgba(7, 12, 9, 0.76);
+  backdrop-filter: blur(8px);
+}
+
+.sql-reward-modal {
+  width: min(440px, 100%);
+  padding: 2rem;
+  color: var(--sql-ink);
+  border: 1px solid var(--sql-line);
+  border-radius: 18px;
+  background: var(--sql-panel);
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.34);
+  text-align: center;
+}
+
+.sql-reward-icon {
+  display: grid;
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 1rem;
+  place-items: center;
+  color: #9a5b0d;
+  border: 1px solid rgba(243, 154, 39, 0.35);
+  border-radius: 50%;
+  background: rgba(243, 154, 39, 0.13);
+}
+
+.sql-reward-modal > span {
+  color: var(--sql-accent-dark);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.sql-reward-modal h2 {
+  margin: 0.5rem 0;
+  color: var(--sql-ink);
+}
+
+.sql-reward-modal p {
+  color: var(--sql-muted);
+}
+
+.sql-reward-totals {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.7rem;
+  margin: 1.3rem 0;
+}
+
+.sql-reward-totals div {
+  padding: 0.9rem;
+  border: 1px solid var(--sql-line);
+  border-radius: 9px;
+  background: var(--sql-soft);
+}
+
+.sql-reward-totals span,
+.sql-reward-totals strong {
+  display: block;
+}
+
+.sql-reward-totals span {
+  color: var(--sql-muted);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.sql-reward-totals strong {
+  margin-top: 0.25rem;
+  color: var(--sql-ink);
+  font-size: 1.45rem;
+}
+
+.sql-reward-modal > button {
+  width: 100%;
+}
+
+@keyframes sql-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 980px) {
+  .sql-lab-workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .sql-lab-sidebar {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 700px) {
+  .sql-lab-page {
+    padding: 1rem;
+  }
+
+  .sql-lab-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .sql-lab-status {
+    width: 100%;
+  }
+
+  .sql-search-form > div,
+  .sql-lab-sidebar {
+    grid-template-columns: 1fr;
+  }
+
+  .sql-search-form button {
+    width: 100%;
+  }
+
+  .sql-results-table,
+  .sql-results-table tbody,
+  .sql-results-table tr,
+  .sql-results-table td {
+    display: block;
+  }
+
+  .sql-results-table thead {
+    display: none;
+  }
+
+  .sql-results-table tr {
+    padding: 0.65rem;
+    border-bottom: 1px solid var(--sql-line);
+  }
+
+  .sql-results-table tr:last-child {
+    border-bottom: 0;
+  }
+
+  .sql-results-table td {
+    display: grid;
+    grid-template-columns: 105px minmax(0, 1fr);
+    gap: 0.6rem;
+    padding: 0.45rem;
+    border: 0;
+  }
+
+  .sql-results-table td::before {
+    content: attr(data-label);
+    color: var(--sql-muted);
+    font-size: 0.67rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+}

--- a/frontend/src/challenges/sqlInjection/SqlInjectionSandbox.tsx
+++ b/frontend/src/challenges/sqlInjection/SqlInjectionSandbox.tsx
@@ -1,0 +1,408 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { motion } from 'motion/react';
+import {
+  ArrowLeft,
+  Check,
+  CheckCircle2,
+  Copy,
+  Database,
+  RefreshCw,
+  Search,
+  Send,
+  ShieldCheck,
+  TerminalSquare,
+  Trophy,
+} from 'lucide-react';
+
+import { useAuth } from '../../context/AuthContext';
+import type {
+  ChallengeSubmitResponse,
+  SqlInjectionSandboxSearchResponse,
+  SqlInjectionSandboxStateResponse,
+} from '../../types/challenge';
+import { challengeAPI } from '../../utils/api';
+import './SqlInjectionSandbox.css';
+
+const completedStatuses = new Set(['completed', 'reward_pending', 'reward_sent', 'reward_failed']);
+
+const getRewardSummary = (state: SqlInjectionSandboxStateResponse): string => {
+  const { reward } = state.challenge;
+  if (!reward.enabled) return 'No reward configured';
+  return reward.xpAmount ? `${reward.bits} bits + ${reward.xpAmount} XP` : `${reward.bits} bits`;
+};
+
+const getRewardStatus = (reward?: ChallengeSubmitResponse['reward']): string => {
+  if (reward?.status === 'sent' || reward?.status === 'already_sent') {
+    return 'Reward synchronized with Prizeversity.';
+  }
+  if (reward?.status === 'failed') {
+    return 'Challenge complete. Reward synchronization needs attention.';
+  }
+  return 'Challenge complete.';
+};
+
+function SqlInjectionSandbox() {
+  const { slug = '' } = useParams();
+  const navigate = useNavigate();
+  const { user, loading: authLoading } = useAuth();
+  const [state, setState] = useState<SqlInjectionSandboxStateResponse | null>(null);
+  const [searchInput, setSearchInput] = useState('');
+  const [searchResult, setSearchResult] = useState<SqlInjectionSandboxSearchResponse | null>(null);
+  const [flag, setFlag] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [searching, setSearching] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [submitMessage, setSubmitMessage] = useState('');
+  const [copiedValue, setCopiedValue] = useState('');
+  const [rewardModalOpen, setRewardModalOpen] = useState(false);
+  const [submitReward, setSubmitReward] = useState<ChallengeSubmitResponse['reward']>();
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      navigate(`/auth?redirect=${encodeURIComponent(`/challenges/${slug}/lab`)}`, {
+        replace: true,
+      });
+      return;
+    }
+
+    let active = true;
+    setLoading(true);
+    setError('');
+    challengeAPI
+      .getSqlInjectionSandbox(slug)
+      .then((response) => {
+        if (active) setState(response);
+      })
+      .catch((requestError: unknown) => {
+        if (active) {
+          setError(
+            requestError instanceof Error
+              ? requestError.message
+              : 'The SQL sandbox could not be loaded.'
+          );
+        }
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [authLoading, navigate, slug, user]);
+
+  const isCompleted = completedStatuses.has(state?.progress.status || '');
+
+  const handleSearch = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!searchInput) {
+      setError('Enter a search term or SQL payload.');
+      return;
+    }
+
+    setSearching(true);
+    setError('');
+    setSubmitMessage('');
+    try {
+      const response = await challengeAPI.searchSqlInjectionSandbox(slug, searchInput);
+      setSearchResult(response);
+    } catch (requestError: unknown) {
+      setError(
+        requestError instanceof Error ? requestError.message : 'The sandbox query could not run.'
+      );
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const handleCopy = async (value: string) => {
+    await navigator.clipboard.writeText(value);
+    setCopiedValue(value);
+    window.setTimeout(() => setCopiedValue(''), 1400);
+  };
+
+  const handleSubmitFlag = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!flag.trim()) {
+      setError('Enter the flag recovered from the restricted row.');
+      return;
+    }
+
+    setSubmitting(true);
+    setError('');
+    setSubmitMessage('');
+    try {
+      const response = await challengeAPI.submit(slug, { flag });
+      setState((current) => (current ? { ...current, progress: response.progress } : current));
+      setSubmitMessage(response.message);
+      if (response.accepted && response.completed) {
+        setFlag('');
+        setSubmitReward(response.reward);
+        setRewardModalOpen(true);
+      }
+    } catch (requestError: unknown) {
+      setError(
+        requestError instanceof Error ? requestError.message : 'The flag could not be submitted.'
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading || authLoading) {
+    return (
+      <main className="sql-lab-page sql-lab-loading">
+        <RefreshCw size={22} aria-hidden="true" />
+        <span>Provisioning isolated database...</span>
+      </main>
+    );
+  }
+
+  if (!state) {
+    return (
+      <main className="sql-lab-page">
+        <section className="sql-lab-failure">
+          <Database size={30} aria-hidden="true" />
+          <span>Sandbox unavailable</span>
+          <h1>SQL Injection Sandbox</h1>
+          <p>{error || 'This lab is not available for your classroom.'}</p>
+          <Link to="/challenges">
+            <ArrowLeft size={16} /> Return to challenges
+          </Link>
+        </section>
+      </main>
+    );
+  }
+
+  const { challenge, progress, sandbox } = state;
+
+  return (
+    <main className="sql-lab-page">
+      <section className="sql-lab-shell">
+        <header className="sql-lab-header">
+          <div className="sql-lab-header-copy">
+            <Link to={`/challenges/${challenge.slug}`} className="sql-lab-back-link">
+              <ArrowLeft size={15} /> Challenge briefing
+            </Link>
+            <span className="sql-lab-kicker">Isolated training environment</span>
+            <h1>{challenge.title}</h1>
+            <p>{challenge.summary}</p>
+          </div>
+          <div className={`sql-lab-status ${isCompleted ? 'complete' : ''}`}>
+            {isCompleted ? <CheckCircle2 size={20} /> : <ShieldCheck size={20} />}
+            <div>
+              <span>{isCompleted ? 'Completed' : 'Sandbox active'}</span>
+              <small>Synthetic data only</small>
+            </div>
+          </div>
+        </header>
+
+        {error && <div className="sql-lab-alert error">{error}</div>}
+        {submitMessage && <div className="sql-lab-alert success">{submitMessage}</div>}
+
+        <div className="sql-lab-workspace">
+          <section className="sql-query-console">
+            <div className="sql-panel-heading">
+              <div>
+                <span>Archive directory</span>
+                <h2>Record search</h2>
+              </div>
+              <Database size={22} aria-hidden="true" />
+            </div>
+
+            <form className="sql-search-form" onSubmit={handleSearch}>
+              <label htmlFor="sql-search-input">Search by record title</label>
+              <div>
+                <input
+                  id="sql-search-input"
+                  value={searchInput}
+                  onChange={(event) => setSearchInput(event.target.value)}
+                  maxLength={sandbox.maxInputLength}
+                  autoComplete="off"
+                  spellCheck={false}
+                  placeholder="Cloud orientation"
+                />
+                <button type="submit" disabled={searching}>
+                  {searching ? <RefreshCw size={17} /> : <Search size={17} />}
+                  {searching ? 'Running' : 'Search'}
+                </button>
+              </div>
+              <small>
+                Input is inserted into the application query exactly as entered. Stacked statements
+                are disabled.
+              </small>
+            </form>
+
+            <div className="sql-statement-viewer">
+              <div>
+                <TerminalSquare size={16} aria-hidden="true" />
+                <span>Executed statement</span>
+              </div>
+              <code>
+                {searchResult?.statement ||
+                  `SELECT ... FROM ${sandbox.tableName} WHERE title ILIKE '%[input]%' AND published = TRUE`}
+              </code>
+            </div>
+
+            <div className="sql-results-heading">
+              <span>Query results</span>
+              <strong>{searchResult ? `${searchResult.rowCount} rows` : 'Not run'}</strong>
+            </div>
+
+            {searchResult?.queryError ? (
+              <div className="sql-query-error">{searchResult.queryError}</div>
+            ) : searchResult && searchResult.rows.length > 0 ? (
+              <div className="sql-results-table-wrap">
+                <table className="sql-results-table">
+                  <thead>
+                    <tr>
+                      <th>ID</th>
+                      <th>Title</th>
+                      <th>Department</th>
+                      <th>Classification</th>
+                      <th>Content</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {searchResult.rows.map((row) => {
+                      const isFlag = row.content.startsWith('FLAG{');
+                      return (
+                        <tr key={row.id} className={isFlag ? 'restricted' : ''}>
+                          <td data-label="ID">{row.id}</td>
+                          <td data-label="Title">{row.title}</td>
+                          <td data-label="Department">{row.department}</td>
+                          <td data-label="Classification">
+                            <span>{row.classification}</span>
+                          </td>
+                          <td data-label="Content">
+                            <div className="sql-result-content">
+                              <code>{row.content}</code>
+                              {isFlag && (
+                                <button
+                                  type="button"
+                                  onClick={() => handleCopy(row.content)}
+                                  aria-label="Copy recovered flag"
+                                >
+                                  {copiedValue === row.content ? (
+                                    <Check size={15} />
+                                  ) : (
+                                    <Copy size={15} />
+                                  )}
+                                </button>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+                {searchResult.truncated && (
+                  <small className="sql-results-truncated">Additional rows were truncated.</small>
+                )}
+              </div>
+            ) : searchResult ? (
+              <div className="sql-results-empty">No archive records matched that query.</div>
+            ) : (
+              <div className="sql-results-empty">Run a search to inspect the result set.</div>
+            )}
+          </section>
+
+          <aside className="sql-lab-sidebar">
+            <section className="sql-mission-card">
+              <span>Objective</span>
+              <h2>Recover the restricted row</h2>
+              <p>
+                Normal searches return published records only. Alter the query logic, locate the
+                personalized flag, and submit it below.
+              </p>
+              <dl>
+                <div>
+                  <dt>Table</dt>
+                  <dd>{sandbox.tableName}</dd>
+                </div>
+                <div>
+                  <dt>Attempts</dt>
+                  <dd>{progress.attemptCount}</dd>
+                </div>
+                <div>
+                  <dt>Reward</dt>
+                  <dd>{getRewardSummary(state)}</dd>
+                </div>
+              </dl>
+            </section>
+
+            <section className="sql-flag-card">
+              <span>Completion proof</span>
+              <h2>Submit recovered flag</h2>
+              {isCompleted ? (
+                <div className="sql-completed-state">
+                  <CheckCircle2 size={24} aria-hidden="true" />
+                  <strong>Challenge completed</strong>
+                  <p>{progress.lastValidationMessage}</p>
+                </div>
+              ) : (
+                <form onSubmit={handleSubmitFlag}>
+                  <label htmlFor="sql-flag-input">Personalized flag</label>
+                  <input
+                    id="sql-flag-input"
+                    value={flag}
+                    onChange={(event) => setFlag(event.target.value)}
+                    placeholder="FLAG{...}"
+                    autoComplete="off"
+                    spellCheck={false}
+                  />
+                  <button type="submit" disabled={submitting}>
+                    <Send size={16} aria-hidden="true" />
+                    {submitting ? 'Validating' : 'Submit flag'}
+                  </button>
+                  {progress.lastValidationMessage && (
+                    <small>{progress.lastValidationMessage}</small>
+                  )}
+                </form>
+              )}
+            </section>
+          </aside>
+        </div>
+      </section>
+
+      {rewardModalOpen && (
+        <div className="sql-reward-overlay" role="dialog" aria-modal="true">
+          <motion.div
+            className="sql-reward-modal"
+            initial={{ opacity: 0, scale: 0.94, y: 22 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            transition={{ type: 'spring', stiffness: 250, damping: 22 }}
+          >
+            <div className="sql-reward-icon" aria-hidden="true">
+              <Trophy size={31} />
+            </div>
+            <span>Exploit confirmed</span>
+            <h2>Restricted row recovered</h2>
+            <p>{getRewardStatus(submitReward)}</p>
+            {challenge.reward.enabled && (
+              <div className="sql-reward-totals">
+                <div>
+                  <span>Bits</span>
+                  <strong>{challenge.reward.bits}</strong>
+                </div>
+                <div>
+                  <span>XP</span>
+                  <strong>{challenge.reward.xpAmount || 0}</strong>
+                </div>
+              </div>
+            )}
+            <button type="button" onClick={() => setRewardModalOpen(false)}>
+              Continue
+            </button>
+          </motion.div>
+        </div>
+      )}
+    </main>
+  );
+}
+
+export default SqlInjectionSandbox;

--- a/frontend/src/pages/ChallengeDetail.tsx
+++ b/frontend/src/pages/ChallengeDetail.tsx
@@ -5,6 +5,7 @@ import {
   ArrowLeft,
   CheckCircle2,
   Clock3,
+  Database,
   Download,
   Link2,
   Lock,
@@ -110,7 +111,10 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
 
   const isCompleted = completedStatuses.has(progress?.status || '');
   const isManualReview = challenge?.validationType === 'manual_review';
-  const isCipheredSeal = challenge?.experience?.type === 'ciphered_seal';
+  const cipheredSealExperience =
+    challenge?.experience?.type === 'ciphered_seal' ? challenge.experience : null;
+  const isCipheredSeal = Boolean(cipheredSealExperience);
+  const isSqlInjection = challenge?.experience?.type === 'sql_injection';
   const rewardLocked = Boolean(
     user && challenge?.reward.enabled && rewardLink && !rewardLink.linked
   );
@@ -128,6 +132,10 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
       const response = await challengeAPI.start(slug);
       setChallenge(response.challenge);
       setProgress(response.progress);
+      if (response.challenge.experience?.type === 'sql_injection') {
+        navigate(`/challenges/${slug}/lab`);
+        return;
+      }
       setSuccess('Challenge started.');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to start challenge');
@@ -243,11 +251,11 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
               <div className="challenge-instructions">{challenge.instructions}</div>
             )}
 
-            {isCipheredSeal && challenge.experience && (
+            {cipheredSealExperience && (
               <div className="ciphered-seal-discovery">
                 <div className="ciphered-seal-artifact">
                   <img
-                    src={challenge.experience.imagePath}
+                    src={cipheredSealExperience.imagePath}
                     alt="An unlabeled technical shrine diagram with four seals"
                   />
                   <span aria-hidden="true">Artifact 01</span>
@@ -260,7 +268,7 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
                     height resolve the numeric application route described in the briefing.
                   </p>
                   <a
-                    href={challenge.experience.imagePath}
+                    href={cipheredSealExperience.imagePath}
                     download="ciphered-seal-map.png"
                     className="ciphered-seal-download"
                   >
@@ -323,6 +331,11 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
                   </div>
                 )}
                 {progress.lastValidationMessage && <small>{progress.lastValidationMessage}</small>}
+                {isSqlInjection && (
+                  <button type="button" onClick={() => navigate(`/challenges/${slug}/lab`)}>
+                    <Database size={16} aria-hidden="true" /> Reopen sandbox
+                  </button>
+                )}
               </div>
             ) : progress.status === 'pending_review' ? (
               <div className="challenge-submit-state pending">
@@ -341,11 +354,23 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
                   This challenge does not accept a secret here. Resolve the artifact metadata, then
                   navigate to the resulting <code>/challenge/&lt;route&gt;</code> path.
                 </small>
-                {challenge.experience && (
-                  <a href={challenge.experience.imagePath} download="ciphered-seal-map.png">
+                {cipheredSealExperience && (
+                  <a href={cipheredSealExperience.imagePath} download="ciphered-seal-map.png">
                     <Download size={16} aria-hidden="true" /> Download artifact
                   </a>
                 )}
+              </div>
+            ) : isSqlInjection ? (
+              <div className="challenge-submit-state">
+                <Database size={24} aria-hidden="true" />
+                <p>Isolated SQL lab unlocked</p>
+                <small>
+                  Open the synthetic archive database, manipulate its vulnerable search query, and
+                  recover your personalized completion flag.
+                </small>
+                <button type="button" onClick={() => navigate(`/challenges/${slug}/lab`)}>
+                  Open SQL sandbox
+                </button>
               </div>
             ) : (
               <form onSubmit={handleSubmit} className="challenge-submit-form">

--- a/frontend/src/types/challenge.ts
+++ b/frontend/src/types/challenge.ts
@@ -27,6 +27,14 @@ export interface CipheredSealExperience {
   imagePath: string;
 }
 
+export interface SqlInjectionExperience {
+  type: 'sql_injection';
+  tableName: string;
+  maxInputLength: number;
+}
+
+export type ChallengeExperience = CipheredSealExperience | SqlInjectionExperience;
+
 export interface ChallengeRewardConfig extends ChallengeRewardPreview {
   activityName?: string;
   description?: string;
@@ -74,7 +82,7 @@ export interface ChallengeListItem {
   tags: string[];
   version: number;
   validationType?: ChallengeValidationType;
-  experience?: CipheredSealExperience;
+  experience?: ChallengeExperience;
   startsAt?: string | null;
   endsAt?: string | null;
   rewardIntegrationInstanceId?: string | null;
@@ -150,6 +158,29 @@ export interface CipheredSealResolveResponse {
     leftSeal: 0 | 1;
     rightSeal: 0 | 1;
   };
+}
+
+export interface SqlInjectionSandboxStateResponse {
+  challenge: ChallengeDetail;
+  progress: ChallengeProgress;
+  rewardLink: ChallengeRewardLinkSummary;
+  sandbox: SqlInjectionExperience;
+}
+
+export interface SqlInjectionSandboxRow {
+  id: number;
+  title: string;
+  department: string;
+  classification: string;
+  content: string;
+}
+
+export interface SqlInjectionSandboxSearchResponse {
+  statement: string;
+  rows: SqlInjectionSandboxRow[];
+  rowCount: number;
+  truncated: boolean;
+  queryError?: string;
 }
 
 export interface AdminChallenge extends ChallengeDetail {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -19,6 +19,8 @@ import type {
   ChallengeSubmitResponse,
   CipheredSealResolveResponse,
   CipheredSealRouteStateResponse,
+  SqlInjectionSandboxSearchResponse,
+  SqlInjectionSandboxStateResponse,
   ChallengeProgressStatus,
   ChallengeStatus,
 } from '../types/challenge';
@@ -560,6 +562,20 @@ export const challengeAPI = {
     return apiRequest(`/challenges/ciphered-seal/route/${encodeURIComponent(routeKey)}/resolve`, {
       method: 'POST',
       body: JSON.stringify({ seedNumber }),
+    });
+  },
+
+  getSqlInjectionSandbox: async (slug: string): Promise<SqlInjectionSandboxStateResponse> => {
+    return apiRequest(`/challenges/${encodeURIComponent(slug)}/sql-sandbox`);
+  },
+
+  searchSqlInjectionSandbox: async (
+    slug: string,
+    query: string
+  ): Promise<SqlInjectionSandboxSearchResponse> => {
+    return apiRequest(`/challenges/${encodeURIComponent(slug)}/sql-sandbox/search`, {
+      method: 'POST',
+      body: JSON.stringify({ query }),
     });
   },
 


### PR DESCRIPTION
Add a curated pg-mem-backed SQL injection lab with synthetic data, assignment-scoped personalized flags, rate-limited query endpoints, and secure backend validation.

Integrate challenge progress and Prizeversity rewards, add the responsive student lab experience, register catalog seeding and migration support, document security and deployment behavior, and cover the sandbox with focused tests.