### PR TITLE
feat: add personalized PCAP forensics challenge

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "seed-robots-trap-challenge": "tsx scripts/challenges/seedRobotsTrapChallenge.ts",
     "seed-ciphered-seal-challenge": "tsx scripts/challenges/seedCipheredSealChallenge.ts",
     "seed-sql-injection-challenge": "tsx scripts/challenges/seedSqlInjectionSandboxChallenge.ts",
+    "seed-pcap-forensics-challenge": "tsx scripts/challenges/seedPcapForensicsChallenge.ts",
     "migrate-challenge-catalog": "tsx scripts/challenges/migrateChallengeCatalogAssignments.ts"
   },
   "dependencies": {

--- a/backend/scripts/challenges/migrateChallengeCatalogAssignments.ts
+++ b/backend/scripts/challenges/migrateChallengeCatalogAssignments.ts
@@ -19,6 +19,7 @@ const curatedKeys = new Set([
   'robots_txt_trap',
   'ciphered_seal_protocol',
   'sql_injection_sandbox',
+  'pcap_forensics',
 ]);
 
 const toAssignmentStatus = (status: string): ChallengeAssignmentStatus => {

--- a/backend/scripts/challenges/seedPcapForensicsChallenge.ts
+++ b/backend/scripts/challenges/seedPcapForensicsChallenge.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env bun
+
+import mongoose from 'mongoose';
+
+import env from '../../src/config/env';
+import logger from '../../src/config/logger';
+import Challenge from '../../src/models/Challenge';
+import User from '../../src/models/User';
+
+const log = logger.child({ module: 'seedPcapForensicsChallenge' });
+const challengeKey = 'pcap_forensics';
+
+async function seedPcapForensicsChallenge(): Promise<void> {
+  if (!env.MONGODB_URI) {
+    throw new Error('MONGODB_URI is required');
+  }
+
+  await mongoose.connect(env.MONGODB_URI);
+  log.info('connected to mongodb.');
+
+  const owner = await User.findOne({ role: { $in: ['superuser', 'admin'] }, status: 'active' })
+    .sort({ role: -1, createdAt: 1 })
+    .select('_id email role');
+
+  if (!owner) {
+    throw new Error('An active admin or superuser is required to seed the challenge.');
+  }
+
+  const challenge = await Challenge.findOneAndUpdate(
+    { key: challengeKey },
+    {
+      $set: {
+        key: challengeKey,
+        slug: 'pcap-forensics',
+        title: 'PCAP Forensics',
+        summary:
+          'Analyze DNS and HTTP traffic in Wireshark to recover a personalized flag from a packet capture.',
+        description:
+          'A student workstation contacted an unfamiliar telemetry service. Investigate the supplied network capture, identify the relevant protocol activity, and recover the evidence embedded in the outbound request.',
+        instructions:
+          'Start the challenge and download the PCAP evidence file. Open it in Wireshark, review the protocol hierarchy, and use display filters such as dns and http.request to narrow the traffic. Inspect request fields or follow the relevant TCP stream, then submit the complete FLAG{...} value you recover.',
+        source: 'curated',
+        status: 'published',
+        kind: 'single',
+        difficulty: 'medium',
+        estimatedMinutes: 20,
+        tags: ['pcap', 'wireshark', 'forensics', 'networking', 'security'],
+        publishedAt: new Date(),
+        startsAt: null,
+        endsAt: null,
+        rewardIntegrationInstanceId: null,
+        validation: {
+          type: 'pcap_forensics',
+          fileName: 'network-evidence.pcap',
+          successMessage: 'Packet evidence validated. PCAP forensics challenge complete.',
+        },
+        reward: {
+          enabled: true,
+          bits: 50,
+          xpMode: 'custom',
+          xpAmount: 30,
+          activityName: 'PCAP Forensics',
+          description: 'Completed PCAP Forensics',
+          applyGroupMultipliers: true,
+          applyPersonalMultipliers: true,
+        },
+        updatedBy: owner._id,
+      },
+      $unset: {
+        maxAttempts: '',
+      },
+      $setOnInsert: {
+        version: 1,
+        assignmentMigrationVersion: 1,
+        createdBy: owner._id,
+      },
+    },
+    { new: true, upsert: true, setDefaultsOnInsert: true }
+  );
+
+  log.info(`seeded challenge ${challenge.title} (${challenge.slug}).`);
+  log.info(`owner: ${owner.email} (${owner.role}).`);
+}
+
+seedPcapForensicsChallenge()
+  .catch((error: unknown) => {
+    log.error('failed to seed PCAP Forensics.', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await mongoose.disconnect();
+    log.info('disconnected from mongodb.');
+  });

--- a/backend/src/controllers/challengeController.ts
+++ b/backend/src/controllers/challengeController.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express';
 import type { ChallengeDifficulty } from '../models/Challenge';
 import {
   ChallengeServiceError,
+  downloadPcapForensicsCapture,
   getCipheredSealRouteState,
   getChallengeProgress,
   getPublishedChallenge,
@@ -127,6 +128,27 @@ export const searchSqlInjection = async (req: Request, res: Response): Promise<v
     res
       .status(getErrorStatus(error, 400))
       .json(getErrorBody(error, 'Unable to run SQL sandbox query'));
+  }
+};
+
+export const downloadPcapCapture = async (req: Request, res: Response): Promise<void> => {
+  try {
+    if (!req.user?.id) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    const result = await downloadPcapForensicsCapture(req.params.slug, req.user.id);
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Disposition', `attachment; filename="${result.fileName}"`);
+    res.setHeader('Content-Length', String(result.capture.length));
+    res.setHeader('Cache-Control', 'private, no-store');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.status(200).send(result.capture);
+  } catch (error: unknown) {
+    res
+      .status(getErrorStatus(error, 404))
+      .json(getErrorBody(error, 'Unable to generate packet capture'));
   }
 };
 

--- a/backend/src/routes/challenges.ts
+++ b/backend/src/routes/challenges.ts
@@ -16,6 +16,16 @@ const sqlSandboxSearchLimiter = rateLimit({
   legacyHeaders: false,
 });
 
+const pcapDownloadLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+  message: {
+    error: 'Too many capture downloads. Wait a moment before trying again.',
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 router.get('/', optionalJwt, challengeController.listChallenges);
 router.get('/ciphered-seal/route/:routeKey', checkJwt, challengeController.getCipheredSealState);
 router.post(
@@ -30,6 +40,7 @@ router.post(
   sqlSandboxSearchLimiter,
   challengeController.searchSqlInjection
 );
+router.get('/:slug/pcap', checkJwt, pcapDownloadLimiter, challengeController.downloadPcapCapture);
 router.get('/:slug', optionalJwt, challengeController.getChallenge);
 router.get('/:slug/progress', checkJwt, challengeController.getProgress);
 router.post('/:slug/start', checkJwt, challengeController.start);

--- a/backend/src/services/challengeService.ts
+++ b/backend/src/services/challengeService.ts
@@ -43,6 +43,11 @@ import {
   runSqlInjectionSandboxQuery,
   SQL_INJECTION_VALIDATOR_TYPE,
 } from './sqlInjectionSandboxService';
+import {
+  buildPcapForensicsCapture,
+  getPcapForensicsPublicExperience,
+  PCAP_FORENSICS_VALIDATOR_TYPE,
+} from './pcapForensicsService';
 
 export type ChallengeErrorCode =
   | 'CHALLENGE_NOT_FOUND'
@@ -351,6 +356,9 @@ const getPublicChallengeExperience = (challenge: IChallengeDocument) => {
     }
     if (getValidatorType(challenge) === SQL_INJECTION_VALIDATOR_TYPE) {
       return getSqlInjectionPublicExperience(challenge.validation);
+    }
+    if (getValidatorType(challenge) === PCAP_FORENSICS_VALIDATOR_TYPE) {
+      return getPcapForensicsPublicExperience(challenge.validation);
     }
     return undefined;
   } catch {
@@ -888,6 +896,32 @@ export const searchSqlInjectionSandbox = async (slug: string, userId: string, in
       400
     );
   }
+};
+
+const getPcapForensicsPlayerContext = async (slug: string, userId: string) => {
+  const { challenge, assignment, user } = await ensureAssignedChallenge(slug, userId);
+  if (getValidatorType(challenge) !== PCAP_FORENSICS_VALIDATOR_TYPE) {
+    throw new ChallengeServiceError('Packet capture not found.', 'CHALLENGE_NOT_FOUND', 404);
+  }
+  if (assignment.reward?.enabled && !hasRewardIdentity(user)) {
+    throw new ChallengeServiceError(
+      'Link your Prizeversity account before downloading this challenge.',
+      'REWARD_LINK_REQUIRED',
+      403
+    );
+  }
+
+  const progress = await getOrCreateProgress(challenge, assignment, userId);
+  return { challenge, user, progress };
+};
+
+export const downloadPcapForensicsCapture = async (slug: string, userId: string) => {
+  const { challenge, user, progress } = await getPcapForensicsPlayerContext(slug, userId);
+  const experience = getPcapForensicsPublicExperience(challenge.validation);
+  return {
+    capture: buildPcapForensicsCapture({ challenge, progress, user }),
+    fileName: experience.fileName,
+  };
 };
 
 export const submitChallenge = async (

--- a/backend/src/services/challengeValidatorService.ts
+++ b/backend/src/services/challengeValidatorService.ts
@@ -17,6 +17,12 @@ import {
   SQL_INJECTION_VALIDATOR_TYPE,
   validateSqlInjectionCompletionToken,
 } from './sqlInjectionSandboxService';
+import {
+  getPcapForensicsSuccessMessage,
+  normalizePcapForensicsConfig,
+  PCAP_FORENSICS_VALIDATOR_TYPE,
+  validatePcapForensicsFlag,
+} from './pcapForensicsService';
 
 export interface ChallengeValidatorContext {
   user: IUserDocument;
@@ -95,6 +101,12 @@ interface GenericProofSubmissionPayload {
 }
 
 interface SqlInjectionSubmissionPayload {
+  flag?: string;
+  secret?: string;
+  answer?: string;
+}
+
+interface PcapForensicsSubmissionPayload {
   flag?: string;
   secret?: string;
   answer?: string;
@@ -225,6 +237,15 @@ const normalizeGenericProofPayload = (payload: unknown): GenericProofSubmissionP
 };
 
 const normalizeSqlInjectionPayload = (payload: unknown): SqlInjectionSubmissionPayload => {
+  if (!isRecord(payload)) return {};
+  return {
+    flag: cleanString(payload.flag) || undefined,
+    secret: cleanString(payload.secret) || undefined,
+    answer: cleanString(payload.answer) || undefined,
+  };
+};
+
+const normalizePcapForensicsPayload = (payload: unknown): PcapForensicsSubmissionPayload => {
   if (!isRecord(payload)) return {};
   return {
     flag: cleanString(payload.flag) || undefined,
@@ -551,6 +572,50 @@ const sqlInjectionValidator: ChallengeValidator = {
   },
 };
 
+const pcapForensicsValidator: ChallengeValidator = {
+  type: PCAP_FORENSICS_VALIDATOR_TYPE,
+
+  async validate(rawConfig, rawPayload, context) {
+    normalizePcapForensicsConfig(rawConfig);
+    const payload = normalizePcapForensicsPayload(rawPayload);
+    const submittedFlag = cleanString(payload.flag || payload.secret || payload.answer);
+
+    if (!submittedFlag) {
+      return {
+        accepted: false,
+        outcome: 'rejected',
+        message: 'Submit the flag recovered from the packet capture.',
+      };
+    }
+
+    const accepted = validatePcapForensicsFlag(submittedFlag, context);
+    return {
+      accepted,
+      outcome: accepted ? 'accepted' : 'rejected',
+      message: accepted
+        ? getPcapForensicsSuccessMessage(rawConfig)
+        : 'That flag does not belong to this packet capture.',
+      publicDetails: {
+        captureValidated: true,
+      },
+      privateDetails: {
+        personalizedCapture: true,
+        challengeVersion: context.challenge.version,
+      },
+    };
+  },
+
+  sanitizePayload(payload) {
+    const normalizedPayload = normalizePcapForensicsPayload(payload);
+    return {
+      submitted: Boolean(
+        normalizedPayload.flag || normalizedPayload.secret || normalizedPayload.answer
+      ),
+      flag: '[redacted]',
+    };
+  },
+};
+
 export const registerChallengeValidator = (validator: ChallengeValidator): void => {
   validators.set(validator.type, validator);
 };
@@ -650,6 +715,10 @@ export const prepareChallengeValidationConfigForStorage = (
     return { ...normalizeSqlInjectionSandboxConfig({ ...config, type }) };
   }
 
+  if (type === PCAP_FORENSICS_VALIDATOR_TYPE) {
+    return { ...normalizePcapForensicsConfig({ ...config, type }) };
+  }
+
   getChallengeValidator(type);
   return {
     ...config,
@@ -662,3 +731,4 @@ registerChallengeValidator(staticSecretValidator);
 registerChallengeValidator(manualReviewValidator);
 registerChallengeValidator(cipheredSealValidator);
 registerChallengeValidator(sqlInjectionValidator);
+registerChallengeValidator(pcapForensicsValidator);

--- a/backend/src/services/pcapForensicsService.ts
+++ b/backend/src/services/pcapForensicsService.ts
@@ -1,0 +1,365 @@
+import crypto from 'crypto';
+
+import env from '../config/env';
+import type { IChallengeDocument } from '../models/Challenge';
+import type { IChallengeProgressDocument } from '../models/ChallengeProgress';
+import type { IUserDocument } from '../models/User';
+
+export const PCAP_FORENSICS_VALIDATOR_TYPE = 'pcap_forensics' as const;
+
+const DEFAULT_FILE_NAME = 'network-evidence.pcap';
+const PCAP_PACKET_COUNT = 7;
+
+export interface PcapForensicsConfig {
+  type: typeof PCAP_FORENSICS_VALIDATOR_TYPE;
+  fileName: string;
+  successMessage?: string;
+}
+
+export interface PcapForensicsContext {
+  challenge: IChallengeDocument;
+  progress: IChallengeProgressDocument;
+  user: IUserDocument;
+}
+
+const cleanString = (value: unknown): string => {
+  return typeof value === 'string' ? value.trim() : '';
+};
+
+export const normalizePcapForensicsConfig = (
+  rawConfig: Record<string, unknown>
+): PcapForensicsConfig => {
+  if (rawConfig.type !== PCAP_FORENSICS_VALIDATOR_TYPE) {
+    throw new Error('Invalid PCAP forensics validator config type.');
+  }
+
+  const fileName = cleanString(rawConfig.fileName) || DEFAULT_FILE_NAME;
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{1,78}\.pcap$/.test(fileName)) {
+    throw new Error('PCAP fileName must be a safe filename ending in .pcap.');
+  }
+
+  return {
+    type: PCAP_FORENSICS_VALIDATOR_TYPE,
+    fileName,
+    successMessage: cleanString(rawConfig.successMessage) || undefined,
+  };
+};
+
+const getSigningSecret = (): string => {
+  const secret = env.CHALLENGE_SIGNING_SECRET || env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('Challenge signing secret is not configured.');
+  }
+  return secret;
+};
+
+export const buildPcapForensicsFlag = (context: PcapForensicsContext): string => {
+  const digest = crypto
+    .createHmac('sha256', getSigningSecret())
+    .update(
+      [
+        'pcap-forensics',
+        String(context.challenge._id),
+        String(context.challenge.version),
+        String(context.progress.assignmentId),
+        String(context.user._id),
+      ].join(':')
+    )
+    .digest('hex')
+    .slice(0, 24);
+
+  return `FLAG{${digest}}`;
+};
+
+const timingSafeEqual = (submitted: string, expected: string): boolean => {
+  const submittedBuffer = Buffer.from(submitted);
+  const expectedBuffer = Buffer.from(expected);
+  return (
+    submittedBuffer.length === expectedBuffer.length &&
+    crypto.timingSafeEqual(submittedBuffer, expectedBuffer)
+  );
+};
+
+export const validatePcapForensicsFlag = (
+  submittedFlag: string,
+  context: PcapForensicsContext
+): boolean => {
+  return timingSafeEqual(submittedFlag.trim(), buildPcapForensicsFlag(context));
+};
+
+const internetChecksum = (value: Buffer): number => {
+  let sum = 0;
+  for (let offset = 0; offset < value.length; offset += 2) {
+    const high = value[offset];
+    const low = offset + 1 < value.length ? value[offset + 1] : 0;
+    sum += (high << 8) | low;
+    while (sum > 0xffff) {
+      sum = (sum & 0xffff) + (sum >>> 16);
+    }
+  }
+  return ~sum & 0xffff;
+};
+
+const parseIpv4Address = (address: string): Buffer => {
+  const octets = address.split('.').map(Number);
+  if (
+    octets.length !== 4 ||
+    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
+  ) {
+    throw new Error('Invalid IPv4 address in PCAP fixture.');
+  }
+  return Buffer.from(octets);
+};
+
+const parseMacAddress = (address: string): Buffer => {
+  const octets = address.split(':').map((octet) => Number.parseInt(octet, 16));
+  if (octets.length !== 6 || octets.some((octet) => !Number.isInteger(octet))) {
+    throw new Error('Invalid MAC address in PCAP fixture.');
+  }
+  return Buffer.from(octets);
+};
+
+const buildIpv4Packet = (
+  sourceIp: string,
+  destinationIp: string,
+  protocol: number,
+  payload: Buffer,
+  identification: number
+): Buffer => {
+  const header = Buffer.alloc(20);
+  header[0] = 0x45;
+  header[1] = 0;
+  header.writeUInt16BE(header.length + payload.length, 2);
+  header.writeUInt16BE(identification & 0xffff, 4);
+  header.writeUInt16BE(0x4000, 6);
+  header[8] = 64;
+  header[9] = protocol;
+  parseIpv4Address(sourceIp).copy(header, 12);
+  parseIpv4Address(destinationIp).copy(header, 16);
+  header.writeUInt16BE(internetChecksum(header), 10);
+  return Buffer.concat([header, payload]);
+};
+
+const buildEthernetFrame = (
+  sourceMac: string,
+  destinationMac: string,
+  ipv4Packet: Buffer
+): Buffer => {
+  const header = Buffer.alloc(14);
+  parseMacAddress(destinationMac).copy(header, 0);
+  parseMacAddress(sourceMac).copy(header, 6);
+  header.writeUInt16BE(0x0800, 12);
+  return Buffer.concat([header, ipv4Packet]);
+};
+
+const encodeDnsName = (name: string): Buffer => {
+  const labels = name.split('.');
+  const encodedLabels = labels.map((label) => {
+    const bytes = Buffer.from(label, 'ascii');
+    if (bytes.length === 0 || bytes.length > 63) {
+      throw new Error('Invalid DNS label in PCAP fixture.');
+    }
+    return Buffer.concat([Buffer.from([bytes.length]), bytes]);
+  });
+  return Buffer.concat([...encodedLabels, Buffer.from([0])]);
+};
+
+const buildDnsQuery = (transactionId: number, name: string): Buffer => {
+  const header = Buffer.alloc(12);
+  header.writeUInt16BE(transactionId, 0);
+  header.writeUInt16BE(0x0100, 2);
+  header.writeUInt16BE(1, 4);
+
+  const questionFooter = Buffer.alloc(4);
+  questionFooter.writeUInt16BE(1, 0);
+  questionFooter.writeUInt16BE(1, 2);
+  return Buffer.concat([header, encodeDnsName(name), questionFooter]);
+};
+
+const buildUdpDatagram = (sourcePort: number, destinationPort: number, payload: Buffer): Buffer => {
+  const header = Buffer.alloc(8);
+  header.writeUInt16BE(sourcePort, 0);
+  header.writeUInt16BE(destinationPort, 2);
+  header.writeUInt16BE(header.length + payload.length, 4);
+  header.writeUInt16BE(0, 6);
+  return Buffer.concat([header, payload]);
+};
+
+const buildTcpSegment = (
+  sourceIp: string,
+  destinationIp: string,
+  sourcePort: number,
+  destinationPort: number,
+  sequenceNumber: number,
+  acknowledgementNumber: number,
+  flags: number,
+  payload = Buffer.alloc(0)
+): Buffer => {
+  const header = Buffer.alloc(20);
+  header.writeUInt16BE(sourcePort, 0);
+  header.writeUInt16BE(destinationPort, 2);
+  header.writeUInt32BE(sequenceNumber, 4);
+  header.writeUInt32BE(acknowledgementNumber, 8);
+  header[12] = 5 << 4;
+  header[13] = flags;
+  header.writeUInt16BE(64240, 14);
+
+  const segment = Buffer.concat([header, payload]);
+  const pseudoHeader = Buffer.alloc(12);
+  parseIpv4Address(sourceIp).copy(pseudoHeader, 0);
+  parseIpv4Address(destinationIp).copy(pseudoHeader, 4);
+  pseudoHeader[8] = 0;
+  pseudoHeader[9] = 6;
+  pseudoHeader.writeUInt16BE(segment.length, 10);
+  header.writeUInt16BE(internetChecksum(Buffer.concat([pseudoHeader, segment])), 16);
+  return Buffer.concat([header, payload]);
+};
+
+const buildPcapHeader = (): Buffer => {
+  const header = Buffer.alloc(24);
+  header.writeUInt32LE(0xa1b2c3d4, 0);
+  header.writeUInt16LE(2, 4);
+  header.writeUInt16LE(4, 6);
+  header.writeInt32LE(0, 8);
+  header.writeUInt32LE(0, 12);
+  header.writeUInt32LE(65535, 16);
+  header.writeUInt32LE(1, 20);
+  return header;
+};
+
+const buildPcapRecord = (packet: Buffer, index: number): Buffer => {
+  const header = Buffer.alloc(16);
+  header.writeUInt32LE(1_700_000_000 + index, 0);
+  header.writeUInt32LE(index * 10_000, 4);
+  header.writeUInt32LE(packet.length, 8);
+  header.writeUInt32LE(packet.length, 12);
+  return Buffer.concat([header, packet]);
+};
+
+export const buildPcapForensicsCapture = (context: PcapForensicsContext): Buffer => {
+  const clientIp = '192.0.2.10';
+  const resolverIp = '192.0.2.53';
+  const serverIp = '198.51.100.42';
+  const clientMac = '02:00:00:00:00:10';
+  const resolverMac = '02:00:00:00:00:53';
+  const serverMac = '02:00:00:00:00:42';
+  const sourcePort = 51000;
+  const clientSequence = 1000;
+  const serverSequence = 5000;
+  const flag = buildPcapForensicsFlag(context);
+
+  const dnsNames = ['updates.packet-lab.local', 'inspect-http.packet-lab.local'];
+  const dnsFrames = dnsNames.map((name, index) => {
+    const query = buildDnsQuery(0x2400 + index, name);
+    const udp = buildUdpDatagram(53000 + index, 53, query);
+    return buildEthernetFrame(
+      clientMac,
+      resolverMac,
+      buildIpv4Packet(clientIp, resolverIp, 17, udp, 0x1000 + index)
+    );
+  });
+
+  const syn = buildTcpSegment(clientIp, serverIp, sourcePort, 80, clientSequence, 0, 0x02);
+  const synAck = buildTcpSegment(
+    serverIp,
+    clientIp,
+    80,
+    sourcePort,
+    serverSequence,
+    clientSequence + 1,
+    0x12
+  );
+  const ack = buildTcpSegment(
+    clientIp,
+    serverIp,
+    sourcePort,
+    80,
+    clientSequence + 1,
+    serverSequence + 1,
+    0x10
+  );
+  const httpRequest = Buffer.from(
+    [
+      'GET /collect?source=student-workstation HTTP/1.1',
+      'Host: telemetry.packet-lab.local',
+      'User-Agent: AWS-Student-Builder-Forensics/1.0',
+      `X-Forensics-Flag: ${flag}`,
+      'Accept: */*',
+      'Connection: close',
+      '',
+      '',
+    ].join('\r\n'),
+    'ascii'
+  );
+  const httpSegment = buildTcpSegment(
+    clientIp,
+    serverIp,
+    sourcePort,
+    80,
+    clientSequence + 1,
+    serverSequence + 1,
+    0x18,
+    httpRequest
+  );
+  const httpResponse = Buffer.from(
+    ['HTTP/1.1 204 No Content', 'Server: packet-lab', 'Connection: close', '', ''].join('\r\n'),
+    'ascii'
+  );
+  const responseSegment = buildTcpSegment(
+    serverIp,
+    clientIp,
+    80,
+    sourcePort,
+    serverSequence + 1,
+    clientSequence + 1 + httpRequest.length,
+    0x18,
+    httpResponse
+  );
+
+  const tcpFrames = [
+    buildEthernetFrame(clientMac, serverMac, buildIpv4Packet(clientIp, serverIp, 6, syn, 0x2000)),
+    buildEthernetFrame(
+      serverMac,
+      clientMac,
+      buildIpv4Packet(serverIp, clientIp, 6, synAck, 0x2001)
+    ),
+    buildEthernetFrame(clientMac, serverMac, buildIpv4Packet(clientIp, serverIp, 6, ack, 0x2002)),
+    buildEthernetFrame(
+      clientMac,
+      serverMac,
+      buildIpv4Packet(clientIp, serverIp, 6, httpSegment, 0x2003)
+    ),
+    buildEthernetFrame(
+      serverMac,
+      clientMac,
+      buildIpv4Packet(serverIp, clientIp, 6, responseSegment, 0x2004)
+    ),
+  ];
+
+  const frames = [...dnsFrames, ...tcpFrames];
+  if (frames.length !== PCAP_PACKET_COUNT) {
+    throw new Error('PCAP fixture packet count is inconsistent.');
+  }
+
+  return Buffer.concat([
+    buildPcapHeader(),
+    ...frames.map((frame, index) => buildPcapRecord(frame, index)),
+  ]);
+};
+
+export const getPcapForensicsPublicExperience = (rawConfig: Record<string, unknown>) => {
+  const config = normalizePcapForensicsConfig(rawConfig);
+  return {
+    type: PCAP_FORENSICS_VALIDATOR_TYPE,
+    fileName: config.fileName,
+    packetCount: PCAP_PACKET_COUNT,
+    protocols: ['DNS', 'TCP', 'HTTP'] as const,
+  };
+};
+
+export const getPcapForensicsSuccessMessage = (rawConfig: Record<string, unknown>): string => {
+  return (
+    normalizePcapForensicsConfig(rawConfig).successMessage ||
+    'Packet evidence validated. PCAP forensics challenge complete.'
+  );
+};

--- a/backend/tests/pcapForensicsService.test.ts
+++ b/backend/tests/pcapForensicsService.test.ts
@@ -1,0 +1,90 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+
+import env from '../src/config/env';
+import type { IChallengeDocument } from '../src/models/Challenge';
+import type { IChallengeProgressDocument } from '../src/models/ChallengeProgress';
+import type { IUserDocument } from '../src/models/User';
+import {
+  buildPcapForensicsCapture,
+  buildPcapForensicsFlag,
+  PcapForensicsContext,
+  validatePcapForensicsFlag,
+} from '../src/services/pcapForensicsService';
+import {
+  sanitizeChallengeSubmissionPayload,
+  validateChallengeSubmission,
+} from '../src/services/challengeValidatorService';
+
+const createContext = (userId: string): PcapForensicsContext => ({
+  challenge: { _id: 'challenge-pcap', version: 2 } as unknown as IChallengeDocument,
+  progress: { assignmentId: 'assignment-pcap' } as unknown as IChallengeProgressDocument,
+  user: { _id: userId } as unknown as IUserDocument,
+});
+
+const readPackets = (capture: Buffer): Buffer[] => {
+  const packets: Buffer[] = [];
+  let offset = 24;
+  while (offset < capture.length) {
+    const includedLength = capture.readUInt32LE(offset + 8);
+    const originalLength = capture.readUInt32LE(offset + 12);
+    expect(includedLength).toBe(originalLength);
+    packets.push(capture.subarray(offset + 16, offset + 16 + includedLength));
+    offset += 16 + includedLength;
+  }
+  expect(offset).toBe(capture.length);
+  return packets;
+};
+
+beforeAll(() => {
+  (env as { CHALLENGE_SIGNING_SECRET?: string }).CHALLENGE_SIGNING_SECRET =
+    'pcap-forensics-test-signing-secret';
+});
+
+describe('PCAP forensics capture', () => {
+  it('builds a valid Ethernet PCAP with DNS and TCP packets', () => {
+    const capture = buildPcapForensicsCapture(createContext('user-1'));
+    const packets = readPackets(capture);
+
+    expect(capture.readUInt32LE(0)).toBe(0xa1b2c3d4);
+    expect(capture.readUInt16LE(4)).toBe(2);
+    expect(capture.readUInt16LE(6)).toBe(4);
+    expect(capture.readUInt32LE(20)).toBe(1);
+    expect(packets).toHaveLength(7);
+    expect(packets.map((packet) => packet.readUInt16BE(12))).toEqual(
+      Array.from({ length: 7 }, () => 0x0800)
+    );
+    expect(packets.map((packet) => packet[23])).toEqual([17, 17, 6, 6, 6, 6, 6]);
+  });
+
+  it('places the personalized flag in an HTTP request', () => {
+    const context = createContext('user-1');
+    const captureText = buildPcapForensicsCapture(context).toString('latin1');
+    const expectedFlag = buildPcapForensicsFlag(context);
+
+    expect(captureText).toContain('inspect-http');
+    expect(captureText).toContain('GET /collect?source=student-workstation HTTP/1.1');
+    expect(captureText).toContain(`X-Forensics-Flag: ${expectedFlag}`);
+    expect(validatePcapForensicsFlag(expectedFlag, context)).toBe(true);
+  });
+
+  it('generates different evidence flags for different students', () => {
+    const firstFlag = buildPcapForensicsFlag(createContext('user-1'));
+    const secondFlag = buildPcapForensicsFlag(createContext('user-2'));
+
+    expect(firstFlag).not.toBe(secondFlag);
+    expect(validatePcapForensicsFlag(firstFlag, createContext('user-2'))).toBe(false);
+  });
+
+  it('uses the registered validator and redacts submitted flags', async () => {
+    const context = createContext('user-1');
+    const config = { type: 'pcap_forensics', fileName: 'network-evidence.pcap' };
+    const flag = buildPcapForensicsFlag(context);
+    const result = await validateChallengeSubmission(config, { flag }, context);
+
+    expect(result.accepted).toBe(true);
+    expect(sanitizeChallengeSubmissionPayload(config, { flag })).toEqual({
+      submitted: true,
+      flag: '[redacted]',
+    });
+  });
+});

--- a/docs-site/authoring/curated-challenges.md
+++ b/docs-site/authoring/curated-challenges.md
@@ -40,6 +40,7 @@ Run seed scripts separately for each environment whose catalog should contain th
 | Robots.txt Trap        | `static_secret`   | Adds `/robots.txt` discovery and a dedicated hidden vault route.                       |
 | Ciphered Seal Protocol | `ciphered_seal`   | Adds a metadata route key, per-user layout, calculator state, and sequence validation. |
 | SQL Injection Sandbox  | `sql_injection`   | Runs vulnerable queries against a disposable, synthetic in-memory database.            |
+| PCAP Forensics         | `pcap_forensics`  | Generates assignment-scoped network evidence for analysis in Wireshark.                |
 
 The Robots.txt challenge demonstrates that a curated experience may reuse a generic validator while still requiring source-controlled routes and presentation.
 
@@ -59,6 +60,22 @@ Operational behavior:
 - The database is rebuilt for every query and retains no student input.
 
 This controlled vulnerability must remain in `sqlInjectionSandboxService.ts`. Do not point its query executor at a persistent or shared database to make the data feel more realistic.
+
+## PCAP Forensics
+
+PCAP Forensics generates a standards-compliant Ethernet capture when a student downloads the evidence. The capture contains synthetic DNS queries, a TCP exchange, and an HTTP request carrying a personalized completion flag. Students analyze the file in Wireshark and submit the recovered flag through the normal challenge endpoint.
+
+The capture is generated from the authenticated player context rather than stored as one shared artifact. Its flag is HMAC-derived from the challenge, challenge version, classroom assignment, and AWS Student Hub user. A capture or flag shared across students therefore cannot complete another student's challenge.
+
+Operational behavior:
+
+- Download requires authentication, an active Prizeversity link, and an active classroom assignment.
+- Downloading starts or resumes assignment-scoped progress but does not consume an attempt.
+- Capture downloads are rate-limited and returned with private, no-store caching.
+- The file contains documentation-range IP addresses and synthetic traffic only.
+- Final flag submission consumes an attempt and uses the standard completion and reward pipeline.
+
+Do not replace the generator with captures of real club, classroom, or student traffic. Curated evidence must not contain production hostnames, credentials, tokens, private IP plans, or personal data.
 
 ## Implementing a curated validator
 

--- a/docs-site/reference/deployment.md
+++ b/docs-site/reference/deployment.md
@@ -63,6 +63,7 @@ bun run seed-aws-cyber-challenge
 bun run seed-robots-trap-challenge
 bun run seed-ciphered-seal-challenge
 bun run seed-sql-injection-challenge
+bun run seed-pcap-forensics-challenge
 ```
 
 Each command uses the active `MONGODB_URI`. Confirm the target before running it.

--- a/docs-site/reference/http-api.md
+++ b/docs-site/reference/http-api.md
@@ -125,6 +125,26 @@ The response contains the executed synthetic statement, bounded result rows, tru
 
 Both sandbox routes enforce authentication, active account linking, published definition state, and the student's active classroom assignment.
 
+### PCAP Forensics route
+
+```text
+GET /challenges/:slug/pcap
+```
+
+Returns a personalized `.pcap` file as `application/octet-stream`. The response is an authenticated, rate-limited binary download with private, no-store caching. Access enforces the student's active Prizeversity link and classroom assignment and starts progress if necessary.
+
+The recovered flag is submitted through the standard endpoint:
+
+```json
+{
+  "payload": {
+    "flag": "FLAG{personalized-value}"
+  }
+}
+```
+
+Capture download does not consume an attempt. Final flag submission does.
+
 ## Admin catalog routes
 
 | Method   | Path                                             | Purpose                                                                               |

--- a/docs-site/reference/security.md
+++ b/docs-site/reference/security.md
@@ -72,6 +72,8 @@ The SQL Injection Sandbox is vulnerable by design, but its SQL boundary is dispo
 
 Do not replace the in-memory adapter with a production database connection. Extending this challenge with persistent data or general-purpose SQL execution changes the security model and requires a separate isolation review.
 
+The PCAP Forensics generator follows the same synthetic-data boundary. It uses documentation-range addresses, fixed fictional hostnames, and a per-student HMAC flag. Captures are generated only after assignment checks, are not stored server-side, and are returned with no-store caching. Never use real packet captures as challenge fixtures unless they have undergone a documented privacy and credential review.
+
 ## Browser trust boundary
 
 The frontend is an untrusted presentation layer. A student can inspect JavaScript, network responses, hidden DOM, and public assets.

--- a/frontend/src/pages/ChallengeDetail.tsx
+++ b/frontend/src/pages/ChallengeDetail.tsx
@@ -77,6 +77,7 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
   const [loading, setLoading] = useState(true);
   const [starting, setStarting] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [downloadingCapture, setDownloadingCapture] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [rewardModalOpen, setRewardModalOpen] = useState(false);
@@ -115,6 +116,9 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
     challenge?.experience?.type === 'ciphered_seal' ? challenge.experience : null;
   const isCipheredSeal = Boolean(cipheredSealExperience);
   const isSqlInjection = challenge?.experience?.type === 'sql_injection';
+  const pcapExperience =
+    challenge?.experience?.type === 'pcap_forensics' ? challenge.experience : null;
+  const isPcapForensics = Boolean(pcapExperience);
   const rewardLocked = Boolean(
     user && challenge?.reward.enabled && rewardLink && !rewardLink.linked
   );
@@ -150,7 +154,9 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
       setError(
         isManualReview
           ? 'Enter proof before submitting.'
-          : 'Enter the challenge secret before submitting.'
+          : isPcapForensics
+            ? 'Enter the flag recovered from the packet capture.'
+            : 'Enter the challenge secret before submitting.'
       );
       return;
     }
@@ -162,7 +168,7 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
     try {
       const response = await challengeAPI.submit(
         slug,
-        isManualReview ? { proof: secret } : { secret }
+        isManualReview ? { proof: secret } : isPcapForensics ? { flag: secret } : { secret }
       );
       setProgress(response.progress);
       setSuccess(response.message);
@@ -175,6 +181,28 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
       setError(err instanceof Error ? err.message : 'Failed to submit challenge');
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const handlePcapDownload = async () => {
+    if (!pcapExperience || !user || !progress || progress.status === 'not_started') return;
+
+    setDownloadingCapture(true);
+    setError('');
+    try {
+      const capture = await challengeAPI.downloadPcapCapture(slug);
+      const downloadUrl = URL.createObjectURL(capture);
+      const link = document.createElement('a');
+      link.href = downloadUrl;
+      link.download = pcapExperience.fileName;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.setTimeout(() => URL.revokeObjectURL(downloadUrl), 1000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to download packet capture');
+    } finally {
+      setDownloadingCapture(false);
     }
   };
 
@@ -278,6 +306,62 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
               </div>
             )}
 
+            {pcapExperience && (
+              <div className="pcap-forensics-artifact">
+                <div className="pcap-file-preview" aria-hidden="true">
+                  <div className="pcap-file-bar">
+                    <span />
+                    <span />
+                    <span />
+                    <strong>CAPTURE 01</strong>
+                  </div>
+                  <div className="pcap-traffic-map">
+                    <div className="pcap-node client">CLIENT</div>
+                    <div className="pcap-packet-flow">
+                      <span>DNS</span>
+                      <i />
+                      <span>TCP</span>
+                      <i />
+                      <span>HTTP</span>
+                    </div>
+                    <div className="pcap-node server">SERVER</div>
+                  </div>
+                  <div className="pcap-file-footer">
+                    <span>Ethernet</span>
+                    <span>{pcapExperience.packetCount} packets</span>
+                  </div>
+                </div>
+                <div className="pcap-artifact-briefing">
+                  <span>Personalized evidence</span>
+                  <h3>{pcapExperience.fileName}</h3>
+                  <p>
+                    Open this capture in Wireshark and inspect its DNS and HTTP request traffic. The
+                    evidence file is generated specifically for your challenge assignment.
+                  </p>
+                  <div className="pcap-protocols" aria-label="Protocols present in capture">
+                    {pcapExperience.protocols.map((protocol) => (
+                      <span key={protocol}>{protocol}</span>
+                    ))}
+                  </div>
+                  <button
+                    type="button"
+                    className="pcap-download-button"
+                    onClick={handlePcapDownload}
+                    disabled={
+                      downloadingCapture || !user || !progress || progress.status === 'not_started'
+                    }
+                  >
+                    <Download size={17} aria-hidden="true" />
+                    {downloadingCapture
+                      ? 'Generating capture...'
+                      : !progress || progress.status === 'not_started'
+                        ? 'Start challenge to download'
+                        : 'Download PCAP evidence'}
+                  </button>
+                </div>
+              </div>
+            )}
+
             <div className="challenge-detail-meta-grid">
               <div>
                 <span>Type</span>
@@ -375,7 +459,11 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
             ) : (
               <form onSubmit={handleSubmit} className="challenge-submit-form">
                 <label>
-                  {isManualReview ? 'Submission proof' : 'Challenge secret'}
+                  {isManualReview
+                    ? 'Submission proof'
+                    : isPcapForensics
+                      ? 'Recovered flag'
+                      : 'Challenge secret'}
                   {isManualReview ? (
                     <textarea
                       value={secret}
@@ -388,7 +476,7 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
                       type="text"
                       value={secret}
                       onChange={(event) => setSecret(event.target.value)}
-                      placeholder="Paste the secret value"
+                      placeholder={isPcapForensics ? 'FLAG{...}' : 'Paste the secret value'}
                       disabled={submitting || rewardLocked}
                     />
                   )}

--- a/frontend/src/pages/styles/Challenges.css
+++ b/frontend/src/pages/styles/Challenges.css
@@ -890,6 +890,208 @@
   width: 100%;
 }
 
+.pcap-forensics-artifact {
+  background: linear-gradient(145deg, #17201c, #0d1310);
+  border: 1px solid rgba(243, 154, 39, 0.34);
+  border-radius: 18px;
+  color: #edf2ee;
+  display: grid;
+  gap: 1.4rem;
+  grid-template-columns: minmax(250px, 0.9fr) minmax(0, 1.1fr);
+  margin-top: 1.5rem;
+  overflow: hidden;
+  padding: 1rem;
+  text-align: left;
+}
+
+.pcap-file-preview {
+  background:
+    linear-gradient(rgba(155, 180, 165, 0.07) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(155, 180, 165, 0.07) 1px, transparent 1px), #0a100d;
+  background-size: 24px 24px;
+  border: 1px solid #35443c;
+  display: flex;
+  flex-direction: column;
+  min-height: 240px;
+}
+
+.pcap-file-bar,
+.pcap-file-footer {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.035);
+  display: flex;
+  padding: 0.65rem 0.75rem;
+}
+
+.pcap-file-bar {
+  border-bottom: 1px solid #2b3731;
+  gap: 0.32rem;
+}
+
+.pcap-file-bar > span {
+  background: #66736c;
+  border-radius: 50%;
+  height: 6px;
+  width: 6px;
+}
+
+.pcap-file-bar > span:first-child {
+  background: #f39a27;
+}
+
+.pcap-file-bar strong {
+  color: #819087;
+  font-family: 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.12em;
+  margin-left: auto;
+}
+
+.pcap-traffic-map {
+  align-items: center;
+  display: grid;
+  flex: 1;
+  gap: 0.75rem;
+  grid-template-columns: auto minmax(80px, 1fr) auto;
+  padding: 1.1rem;
+}
+
+.pcap-node {
+  align-items: center;
+  aspect-ratio: 1;
+  border: 1px solid #55665c;
+  display: flex;
+  font-family: 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.55rem;
+  justify-content: center;
+  letter-spacing: 0.08em;
+  max-width: 64px;
+  padding: 0.4rem;
+  position: relative;
+}
+
+.pcap-node::after {
+  border: 1px solid rgba(243, 154, 39, 0.38);
+  content: '';
+  inset: 5px;
+  position: absolute;
+}
+
+.pcap-node.server {
+  border-color: rgba(243, 154, 39, 0.65);
+}
+
+.pcap-packet-flow {
+  align-items: center;
+  display: flex;
+  min-width: 0;
+}
+
+.pcap-packet-flow span {
+  color: #f0ad54;
+  font-family: 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.52rem;
+}
+
+.pcap-packet-flow i {
+  background: linear-gradient(90deg, #405047, #f39a27);
+  flex: 1;
+  height: 1px;
+  margin: 0 0.25rem;
+  min-width: 8px;
+  position: relative;
+}
+
+.pcap-packet-flow i::after {
+  border-bottom: 3px solid transparent;
+  border-left: 5px solid #f39a27;
+  border-top: 3px solid transparent;
+  content: '';
+  position: absolute;
+  right: 0;
+  top: -2px;
+}
+
+.pcap-file-footer {
+  border-top: 1px solid #2b3731;
+  color: #809087;
+  font-family: 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.58rem;
+  justify-content: space-between;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.pcap-artifact-briefing {
+  align-self: center;
+  padding: 0.75rem 0.85rem 0.75rem 0;
+}
+
+.pcap-artifact-briefing > span {
+  color: #f0a13a;
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.pcap-artifact-briefing h3 {
+  color: #f5f7f5;
+  font-family: 'SFMono-Regular', Consolas, monospace;
+  font-size: clamp(1.1rem, 2vw, 1.45rem);
+  font-weight: 500;
+  margin: 0.45rem 0 0.7rem;
+}
+
+.pcap-artifact-briefing p {
+  color: #acb8b0;
+  line-height: 1.6;
+  margin: 0 0 0.85rem;
+}
+
+.pcap-protocols {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-bottom: 1rem;
+}
+
+.pcap-protocols span {
+  border: 1px solid #46564d;
+  color: #bdc9c1;
+  font-family: 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.09em;
+  padding: 0.3rem 0.48rem;
+}
+
+.pcap-download-button {
+  align-items: center;
+  background: #f39a27;
+  border: 1px solid #f39a27;
+  border-radius: 8px;
+  color: #151914;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 800;
+  gap: 0.5rem;
+  justify-content: center;
+  padding: 0.72rem 0.95rem;
+}
+
+.pcap-download-button:hover:not(:disabled) {
+  background: #ffad45;
+}
+
+.pcap-download-button:disabled {
+  background: #303a34;
+  border-color: #46524b;
+  color: #919d95;
+  cursor: not-allowed;
+}
+
 .challenges-info {
   background: var(--card-bg);
   border: 1px solid var(--border-color);
@@ -981,6 +1183,14 @@
 
   .ciphered-seal-discovery {
     grid-template-columns: 1fr;
+  }
+
+  .pcap-forensics-artifact {
+    grid-template-columns: 1fr;
+  }
+
+  .pcap-artifact-briefing {
+    padding: 0.5rem;
   }
 
   .ciphered-seal-briefing {

--- a/frontend/src/types/challenge.ts
+++ b/frontend/src/types/challenge.ts
@@ -33,7 +33,17 @@ export interface SqlInjectionExperience {
   maxInputLength: number;
 }
 
-export type ChallengeExperience = CipheredSealExperience | SqlInjectionExperience;
+export interface PcapForensicsExperience {
+  type: 'pcap_forensics';
+  fileName: string;
+  packetCount: number;
+  protocols: readonly ['DNS', 'TCP', 'HTTP'];
+}
+
+export type ChallengeExperience =
+  | CipheredSealExperience
+  | SqlInjectionExperience
+  | PcapForensicsExperience;
 
 export interface ChallengeRewardConfig extends ChallengeRewardPreview {
   activityName?: string;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -214,6 +214,52 @@ const apiRequest = async <T = any>(endpoint: string, options: RequestOptions = {
   }
 };
 
+const apiBlobRequest = async (endpoint: string): Promise<Blob> => {
+  const url = `${API_BASE_URL}${endpoint}`;
+  const request = () =>
+    fetch(url, {
+      cache: 'no-store',
+      headers: {
+        Accept: 'application/octet-stream',
+        ...(getStoredItem('accessToken')
+          ? { Authorization: `Bearer ${getStoredItem('accessToken')}` }
+          : {}),
+      },
+    });
+
+  try {
+    let response = await request();
+    if (response.status === 401 && getStoredItem('refreshToken')) {
+      try {
+        await refreshTokens();
+      } catch {
+        clearStoredItem('accessToken');
+        clearStoredItem('refreshToken');
+        clearStoredItem('cachedUser');
+        throw new Error('Session expired. Please log in again.');
+      }
+      response = await request();
+    }
+
+    if (!response.ok) {
+      const contentType = response.headers.get('content-type') || '';
+      if (contentType.includes('application/json')) {
+        const data = await response.json();
+        throw new Error(getResponseError(data as JsonRecord, response.status));
+      }
+      throw new Error(`Capture download failed with status ${response.status}.`);
+    }
+
+    return response.blob();
+  } catch (error) {
+    console.error('api download failed.', error);
+    if (error instanceof Error && error.message === 'Failed to fetch') {
+      throw new Error('Unable to connect to the server. Please check your connection.');
+    }
+    throw error;
+  }
+};
+
 // Set item to appropriate storage based on rememberMe
 const setStoredItem = (key: string, value: string): void => {
   const shouldRemember = localStorage.getItem('rememberMe') === 'true';
@@ -577,6 +623,10 @@ export const challengeAPI = {
       method: 'POST',
       body: JSON.stringify({ query }),
     });
+  },
+
+  downloadPcapCapture: async (slug: string): Promise<Blob> => {
+    return apiBlobRequest(`/challenges/${encodeURIComponent(slug)}/pcap`);
   },
 
   progress: async (slug: string): Promise<ChallengeProgressResponse> => {


### PR DESCRIPTION
Generate assignment-scoped packet captures containing synthetic DNS, TCP, and HTTP traffic with personalized completion flags.

Add authenticated evidence downloads, backend validation, challenge progress and Prizeversity rewards, student-facing Wireshark guidance, catalog seeding, documentation, and packet-structure tests.