### PR TITLE
feat: support multi-class Prizeversity memberships and assignment-scoped rewards

### DIFF
--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -9,6 +9,7 @@ import {
   processEmailQueue,
   retryFailedEmail,
 } from '../services/emailService';
+import { deletePrizeversityAccountData } from '../services/rewardIntegrationService';
 
 const log = logger.child({ module: 'adminController' });
 
@@ -154,6 +155,8 @@ export const updateUserRole = async (req: Request, res: Response): Promise<void>
       });
       return;
     }
+
+    await deletePrizeversityAccountData(user._id);
 
     res.json({
       success: true,

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -399,7 +399,9 @@ export const signup = async (req: Request, res: Response): Promise<void> => {
     if (providedUsername) {
       const existingUsername = await User.findOne({ username: providedUsername });
       if (existingUsername) {
-        res.status(409).json({ error: 'That username is already in use. Choose another username.' });
+        res
+          .status(409)
+          .json({ error: 'That username is already in use. Choose another username.' });
         return;
       }
     }

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -43,6 +43,8 @@ interface AwsCredentialUser {
 
 const filter = new Filter();
 const CURRENT_POLICY_VERSION = '2026-06-21';
+const PASSWORD_RESET_REQUEST_MESSAGE =
+  'If an account exists for that email, a verification code is on its way. If it does not arrive, check your spam or junk folder.';
 
 const getJwtSecret = (): string => {
   if (!env.JWT_SECRET) {
@@ -386,14 +388,18 @@ export const signup = async (req: Request, res: Response): Promise<void> => {
 
     const existingUser = await User.findOne({ email });
     if (existingUser) {
-      res.status(400).json({ error: 'Account creation failed. Please check your information.' });
+      res.status(409).json({
+        error: existingUser.auth0Id
+          ? 'An account already exists for this email and uses Google sign-in. Continue with Google instead.'
+          : 'An account already exists for this email. Sign in or reset your password instead.',
+      });
       return;
     }
 
     if (providedUsername) {
       const existingUsername = await User.findOne({ username: providedUsername });
       if (existingUsername) {
-        res.status(400).json({ error: 'Account creation failed. Please check your information.' });
+        res.status(409).json({ error: 'That username is already in use. Choose another username.' });
         return;
       }
     }
@@ -479,8 +485,9 @@ export const signup = async (req: Request, res: Response): Promise<void> => {
     log.error('signup error.', error);
 
     if (getErrorCode(error) === 11000) {
-      res.status(400).json({
-        error: 'Account creation failed. Please check your information.',
+      res.status(409).json({
+        error:
+          'An account already exists with that email or username. Sign in or choose different information.',
       });
       return;
     }
@@ -735,7 +742,7 @@ export const forgotPassword = async (req: Request, res: Response): Promise<void>
       res.json({
         success: true,
         message: isEmail
-          ? 'If an account exists with this email, a reset code has been sent.'
+          ? PASSWORD_RESET_REQUEST_MESSAGE
           : 'If an account exists with this username, you will need to verify your email address.',
       });
       return;
@@ -768,7 +775,7 @@ export const forgotPassword = async (req: Request, res: Response): Promise<void>
 
     res.json({
       success: true,
-      message: 'If an account exists with this email, a reset code has been sent.',
+      message: PASSWORD_RESET_REQUEST_MESSAGE,
     });
   } catch (error: unknown) {
     log.error('forgot password error.', error);

--- a/backend/src/controllers/challengeController.ts
+++ b/backend/src/controllers/challengeController.ts
@@ -22,6 +22,9 @@ const parseChallengeDifficulty = (value: unknown): ChallengeDifficulty | undefin
   return undefined;
 };
 
+const getAssignmentId = (req: Request): string | undefined =>
+  typeof req.query.assignmentId === 'string' ? req.query.assignmentId : undefined;
+
 const getErrorBody = (error: unknown, fallback: string) => {
   if (error instanceof ChallengeServiceError) {
     return {
@@ -56,7 +59,7 @@ export const listChallenges = async (req: Request, res: Response): Promise<void>
 
 export const getChallenge = async (req: Request, res: Response): Promise<void> => {
   try {
-    const result = await getPublishedChallenge(req.params.slug, req.user?.id);
+    const result = await getPublishedChallenge(req.params.slug, req.user?.id, getAssignmentId(req));
     res.json(result);
   } catch (error: unknown) {
     res.status(getErrorStatus(error, 404)).json(getErrorBody(error, 'Unable to load challenge'));
@@ -70,7 +73,11 @@ export const getCipheredSealState = async (req: Request, res: Response): Promise
       return;
     }
 
-    const result = await getCipheredSealRouteState(req.params.routeKey, req.user.id);
+    const result = await getCipheredSealRouteState(
+      req.params.routeKey,
+      req.user.id,
+      getAssignmentId(req)
+    );
     res.json(result);
   } catch (error: unknown) {
     res
@@ -89,7 +96,8 @@ export const resolveCipheredSealSeed = async (req: Request, res: Response): Prom
     const result = await resolveCipheredSealRouteSeed(
       req.params.routeKey,
       req.user.id,
-      req.body?.seedNumber
+      req.body?.seedNumber,
+      getAssignmentId(req)
     );
     res.json(result);
   } catch (error: unknown) {
@@ -106,7 +114,11 @@ export const getSqlInjectionSandbox = async (req: Request, res: Response): Promi
       return;
     }
 
-    const result = await getSqlInjectionSandboxState(req.params.slug, req.user.id);
+    const result = await getSqlInjectionSandboxState(
+      req.params.slug,
+      req.user.id,
+      getAssignmentId(req)
+    );
     res.json(result);
   } catch (error: unknown) {
     res
@@ -122,7 +134,12 @@ export const searchSqlInjection = async (req: Request, res: Response): Promise<v
       return;
     }
 
-    const result = await searchSqlInjectionSandbox(req.params.slug, req.user.id, req.body?.query);
+    const result = await searchSqlInjectionSandbox(
+      req.params.slug,
+      req.user.id,
+      req.body?.query,
+      getAssignmentId(req)
+    );
     res.json(result);
   } catch (error: unknown) {
     res
@@ -138,7 +155,11 @@ export const downloadPcapCapture = async (req: Request, res: Response): Promise<
       return;
     }
 
-    const result = await downloadPcapForensicsCapture(req.params.slug, req.user.id);
+    const result = await downloadPcapForensicsCapture(
+      req.params.slug,
+      req.user.id,
+      getAssignmentId(req)
+    );
     res.setHeader('Content-Type', 'application/octet-stream');
     res.setHeader('Content-Disposition', `attachment; filename="${result.fileName}"`);
     res.setHeader('Content-Length', String(result.capture.length));
@@ -159,7 +180,7 @@ export const getProgress = async (req: Request, res: Response): Promise<void> =>
       return;
     }
 
-    const result = await getChallengeProgress(req.params.slug, req.user.id);
+    const result = await getChallengeProgress(req.params.slug, req.user.id, getAssignmentId(req));
     res.json(result);
   } catch (error: unknown) {
     res
@@ -175,7 +196,7 @@ export const start = async (req: Request, res: Response): Promise<void> => {
       return;
     }
 
-    const result = await startChallenge(req.params.slug, req.user.id);
+    const result = await startChallenge(req.params.slug, req.user.id, getAssignmentId(req));
     res.json(result);
   } catch (error: unknown) {
     res.status(getErrorStatus(error, 400)).json(getErrorBody(error, 'Unable to start challenge'));
@@ -189,7 +210,12 @@ export const submit = async (req: Request, res: Response): Promise<void> => {
       return;
     }
 
-    const result = await submitChallenge(req.params.slug, req.user.id, req.body?.payload);
+    const result = await submitChallenge(
+      req.params.slug,
+      req.user.id,
+      req.body?.payload,
+      getAssignmentId(req)
+    );
     res.json(result);
   } catch (error: unknown) {
     res.status(getErrorStatus(error, 400)).json(getErrorBody(error, 'Unable to submit challenge'));

--- a/backend/src/models/RewardIntegrationLinkVerification.ts
+++ b/backend/src/models/RewardIntegrationLinkVerification.ts
@@ -2,6 +2,7 @@ import mongoose, { HydratedDocument, Model, Schema, Types } from 'mongoose';
 
 export interface IRewardIntegrationLinkVerification {
   awsUserId: Types.ObjectId;
+  instanceKey?: string;
   rewardIntegrationInstanceId?: Types.ObjectId | null;
   prizeversityUserId: string;
   classroomId: string;
@@ -36,6 +37,10 @@ const rewardIntegrationLinkVerificationSchema = new Schema<
       type: Schema.Types.ObjectId,
       ref: 'RewardIntegrationInstance',
       default: null,
+    },
+    instanceKey: {
+      type: String,
+      trim: true,
     },
     prizeversityUserId: {
       type: String,

--- a/backend/src/models/RewardIntegrationMembership.ts
+++ b/backend/src/models/RewardIntegrationMembership.ts
@@ -1,0 +1,117 @@
+import mongoose, { HydratedDocument, Model, Schema, Types } from 'mongoose';
+
+export interface IRewardIntegrationMembership {
+  awsUserId: Types.ObjectId;
+  instanceKey: string;
+  rewardIntegrationInstanceId?: Types.ObjectId | null;
+  prizeversityUserId: string;
+  classroomId: string;
+  email?: string;
+  matchedName?: string;
+  shortId?: string;
+  active: boolean;
+  disabledByUser: boolean;
+  linkedAt: Date;
+  lastVerifiedAt?: Date | null;
+  lastVerificationError?: string;
+  inactiveAt?: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type IRewardIntegrationMembershipDocument = HydratedDocument<IRewardIntegrationMembership>;
+type RewardIntegrationMembershipModel = Model<IRewardIntegrationMembership>;
+
+const rewardIntegrationMembershipSchema = new Schema<
+  IRewardIntegrationMembership,
+  RewardIntegrationMembershipModel
+>(
+  {
+    awsUserId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    instanceKey: {
+      type: String,
+      required: true,
+      trim: true,
+      index: true,
+    },
+    rewardIntegrationInstanceId: {
+      type: Schema.Types.ObjectId,
+      ref: 'RewardIntegrationInstance',
+      default: null,
+      index: true,
+    },
+    prizeversityUserId: {
+      type: String,
+      required: true,
+      trim: true,
+      index: true,
+    },
+    classroomId: {
+      type: String,
+      required: true,
+      trim: true,
+      index: true,
+    },
+    email: {
+      type: String,
+      trim: true,
+      lowercase: true,
+    },
+    matchedName: {
+      type: String,
+      trim: true,
+    },
+    shortId: {
+      type: String,
+      trim: true,
+    },
+    active: {
+      type: Boolean,
+      default: true,
+      index: true,
+    },
+    disabledByUser: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
+    linkedAt: {
+      type: Date,
+      default: Date.now,
+    },
+    lastVerifiedAt: {
+      type: Date,
+      default: null,
+    },
+    lastVerificationError: {
+      type: String,
+      trim: true,
+    },
+    inactiveAt: {
+      type: Date,
+      default: null,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+rewardIntegrationMembershipSchema.index({ awsUserId: 1, instanceKey: 1 }, { unique: true });
+rewardIntegrationMembershipSchema.index(
+  { instanceKey: 1, prizeversityUserId: 1 },
+  { unique: true }
+);
+rewardIntegrationMembershipSchema.index({ awsUserId: 1, active: 1 });
+
+const RewardIntegrationMembership = mongoose.model<
+  IRewardIntegrationMembership,
+  RewardIntegrationMembershipModel
+>('RewardIntegrationMembership', rewardIntegrationMembershipSchema);
+
+export default RewardIntegrationMembership;

--- a/backend/src/routes/rewardIntegration.ts
+++ b/backend/src/routes/rewardIntegration.ts
@@ -6,6 +6,7 @@ import {
   getPrizeversityStatus,
   startPrizeversityAccountLink,
   unlinkPrizeversityAccount,
+  unlinkPrizeversityMembership,
   verifyPrizeversityAccountLink,
 } from '../services/rewardIntegrationService';
 
@@ -49,6 +50,16 @@ router.post('/link', checkJwt, async (req: Request, res: Response): Promise<void
       typeof req.body?.instanceId === 'string' ? req.body.instanceId.trim() : undefined;
     const verification = await startPrizeversityAccountLink(user, { identifier, instanceId });
 
+    if (!verification.verificationRequired) {
+      res.json({
+        message: 'Prizeversity classroom connected successfully',
+        ...verification,
+        status: await getPrizeversityStatus(user),
+        user: user.toSafeObject(),
+      });
+      return;
+    }
+
     res.json({
       message: `Verification code sent to ${verification.maskedEmail}`,
       ...verification,
@@ -81,6 +92,28 @@ router.post('/link/verify', checkJwt, async (req: Request, res: Response): Promi
   } catch (error: unknown) {
     res.status(getErrorStatus(error)).json({
       error: error instanceof Error ? error.message : 'Unable to verify Prizeversity link code',
+    });
+  }
+});
+
+router.delete('/link/:instanceId', checkJwt, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const user = await getAuthenticatedUser(req);
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    await unlinkPrizeversityMembership(user, req.params.instanceId);
+
+    res.json({
+      message: 'Prizeversity classroom disconnected successfully',
+      status: await getPrizeversityStatus(user),
+      user: user.toSafeObject(),
+    });
+  } catch (error: unknown) {
+    res.status(getErrorStatus(error)).json({
+      error: error instanceof Error ? error.message : 'Unable to disconnect classroom',
     });
   }
 });

--- a/backend/src/services/challengeRewardService.ts
+++ b/backend/src/services/challengeRewardService.ts
@@ -5,7 +5,10 @@ import type { IChallengeAssignmentDocument } from '../models/ChallengeAssignment
 import type { IChallengeProgressDocument } from '../models/ChallengeProgress';
 import RewardIntegrationEmission from '../models/RewardIntegrationEmission';
 import type { IUserDocument } from '../models/User';
-import { grantPrizeversityChallengeReward } from './rewardIntegrationService';
+import {
+  getPrizeversityMembershipForInstance,
+  grantPrizeversityChallengeReward,
+} from './rewardIntegrationService';
 
 export interface ChallengeCompletionEvent {
   eventId: string;
@@ -65,9 +68,16 @@ const getCompletionXp = (reward: IChallengeRewardConfig) => {
   };
 };
 
-export const hasRewardIdentity = (user: IUserDocument): boolean => {
-  return Boolean(user.prizeversityUserId && user.prizeversityClassroomId);
-};
+export const hasRewardMembership = async (
+  user: IUserDocument,
+  rewardIntegrationInstanceId: string,
+  forceRefresh = false
+): Promise<boolean> =>
+  Boolean(
+    await getPrizeversityMembershipForInstance(user, rewardIntegrationInstanceId, {
+      forceRefresh,
+    })
+  );
 
 export const grantChallengeCompletionReward = async (
   event: ChallengeCompletionEvent,
@@ -80,32 +90,30 @@ export const grantChallengeCompletionReward = async (
     };
   }
 
-  if (!hasRewardIdentity(user)) {
+  const targetRewardIntegrationInstanceId =
+    event.rewardIntegrationInstanceId || user.rewardIntegrationInstanceId?.toString();
+  if (!targetRewardIntegrationInstanceId) {
+    throw new ChallengeRewardError('This challenge does not have a reward classroom.', 403);
+  }
+
+  const membership = await getPrizeversityMembershipForInstance(
+    user,
+    targetRewardIntegrationInstanceId,
+    { forceRefresh: true }
+  );
+  if (!membership) {
     throw new ChallengeRewardError(
-      'Link your Prizeversity account before completing rewardable challenges.',
+      'Connect the Prizeversity classroom assigned to this challenge before completing it.',
       403
     );
   }
 
   try {
-    const targetRewardIntegrationInstanceId =
-      event.rewardIntegrationInstanceId || user.rewardIntegrationInstanceId?.toString();
-
-    if (
-      event.rewardIntegrationInstanceId &&
-      user.rewardIntegrationInstanceId?.toString() !== event.rewardIntegrationInstanceId
-    ) {
-      throw new ChallengeRewardError(
-        'This challenge belongs to a different Prizeversity classroom.',
-        403
-      );
-    }
-
     const result = await grantPrizeversityChallengeReward({
       awsUserId: event.userId,
-      prizeversityUserId: user.prizeversityUserId as string,
+      prizeversityUserId: membership.prizeversityUserId,
       rewardIntegrationInstanceId: targetRewardIntegrationInstanceId,
-      classroomId: user.prizeversityClassroomId,
+      classroomId: membership.classroomId,
       challengeKey: event.challengeKey,
       activityName: event.reward.activityName || event.challengeTitle,
       description: event.reward.description || `Completed ${event.challengeTitle}`,
@@ -125,7 +133,7 @@ export const grantChallengeCompletionReward = async (
   } catch (error: unknown) {
     const emission = await RewardIntegrationEmission.findOne({
       awsUserId: event.userId,
-      classroomId: user.prizeversityClassroomId,
+      classroomId: membership.classroomId,
       challengeKey: event.challengeKey,
     });
 

--- a/backend/src/services/challengeService.ts
+++ b/backend/src/services/challengeService.ts
@@ -22,7 +22,7 @@ import User, { IUserDocument } from '../models/User';
 import {
   buildChallengeCompletionEvent,
   grantChallengeCompletionReward,
-  hasRewardIdentity,
+  hasRewardMembership,
   RewardGrantResult,
 } from './challengeRewardService';
 import {
@@ -37,7 +37,10 @@ import {
   getCipheredSealPublicExperience,
   resolveSubmittedCipheredSealSeed,
 } from './cipheredSealService';
-import { getPrizeversityStatus } from './rewardIntegrationService';
+import {
+  getActivePrizeversityMemberships,
+  getPrizeversityStatus,
+} from './rewardIntegrationService';
 import {
   getSqlInjectionPublicExperience,
   runSqlInjectionSandboxQuery,
@@ -108,6 +111,14 @@ interface RewardLinkSummary {
   configured: boolean;
   requiredInstanceId?: string | null;
   linkedInstanceId?: string | null;
+  linkedInstanceIds: string[];
+}
+
+interface ChallengeClassroomSummary {
+  instanceId: string;
+  instanceName: string;
+  classroomId: string;
+  classroomName?: string;
 }
 
 interface ChallengeSubmitResult {
@@ -405,7 +416,8 @@ const toProgressDto = (progress: IChallengeProgressDocument | null) => {
 const toPublicChallengeDto = (
   challenge: IChallengeDocument,
   assignment?: IChallengeAssignmentDocument | null,
-  progress?: IChallengeProgressDocument | null
+  progress?: IChallengeProgressDocument | null,
+  classroom?: ChallengeClassroomSummary | null
 ) => ({
   id: String(challenge._id),
   assignmentId: assignment?._id.toString() || null,
@@ -426,9 +438,24 @@ const toPublicChallengeDto = (
   endsAt: assignment ? assignment.endsAt : challenge.endsAt,
   maxAttempts: assignment ? assignment.maxAttempts : challenge.maxAttempts,
   rewardIntegrationInstanceId: getAssignmentScopeId(assignment),
+  classroom: classroom || undefined,
   reward: toRewardPreview(assignment ? assignment.reward : challenge.reward),
   progress: progress === undefined ? undefined : toProgressDto(progress),
 });
+
+const getChallengeClassroomSummary = async (
+  assignment: IChallengeAssignmentDocument
+): Promise<ChallengeClassroomSummary | null> => {
+  const instance = await RewardIntegrationInstance.findById(assignment.rewardIntegrationInstanceId);
+  if (!instance) return null;
+
+  return {
+    instanceId: instance._id.toString(),
+    instanceName: instance.name,
+    classroomId: instance.classroomId,
+    classroomName: instance.classroomName || undefined,
+  };
+};
 
 export const toAdminChallengeDto = (challenge: IChallengeDocument) => ({
   ...toPublicChallengeDto(challenge, null),
@@ -473,15 +500,19 @@ const getRewardLinkSummary = async (
       configured: false,
       requiredInstanceId: requiredInstanceId || null,
       linkedInstanceId: null,
+      linkedInstanceIds: [],
     };
   }
 
   const user = await User.findById(userId);
   const status = await getPrizeversityStatus(user);
-  const linkedInstanceId = status.account?.instanceId || null;
-  const linked = Boolean(
-    status.linked && (!requiredInstanceId || linkedInstanceId === requiredInstanceId)
-  );
+  const linkedInstanceIds = status.memberships
+    .filter((membership) => membership.active && !membership.disabledByUser)
+    .map((membership) => membership.instanceId);
+  const linkedInstanceId = linkedInstanceIds[0] || null;
+  const linked = requiredInstanceId
+    ? linkedInstanceIds.includes(requiredInstanceId)
+    : linkedInstanceIds.length > 0;
 
   return {
     required: true,
@@ -489,6 +520,7 @@ const getRewardLinkSummary = async (
     configured: status.configured,
     requiredInstanceId: requiredInstanceId || null,
     linkedInstanceId,
+    linkedInstanceIds,
   };
 };
 
@@ -496,9 +528,15 @@ interface AssignedChallengeContext {
   challenge: IChallengeDocument;
   assignment: IChallengeAssignmentDocument;
   user: IUserDocument;
+  classroom: ChallengeClassroomSummary | null;
 }
 
-const ensureLinkedChallengeUser = async (userId?: string): Promise<IUserDocument> => {
+interface LinkedChallengeUserContext {
+  user: IUserDocument;
+  instanceIds: Types.ObjectId[];
+}
+
+const ensureLinkedChallengeUser = async (userId?: string): Promise<LinkedChallengeUserContext> => {
   if (!userId || !Types.ObjectId.isValid(userId)) {
     throw new ChallengeServiceError(
       'Link your Prizeversity classroom account before opening challenges.',
@@ -511,43 +549,65 @@ const ensureLinkedChallengeUser = async (userId?: string): Promise<IUserDocument
   if (!user) {
     throw new ChallengeServiceError('User not found.', 'INVALID_CHALLENGE_INPUT', 404);
   }
-  if (!user.rewardIntegrationInstanceId) {
+  const memberships = await getActivePrizeversityMemberships(user, {
+    refreshStale: true,
+  });
+  const instanceIds = memberships
+    .map((membership) => membership.rewardIntegrationInstanceId)
+    .filter((instanceId): instanceId is Types.ObjectId => Boolean(instanceId));
+
+  if (instanceIds.length === 0) {
     throw new ChallengeServiceError(
       'Link your Prizeversity classroom account before opening challenges.',
       'REWARD_LINK_REQUIRED',
       403
     );
   }
-  const activeInstance = await RewardIntegrationInstance.exists({
-    _id: user.rewardIntegrationInstanceId,
-    active: true,
-  });
-  if (!activeInstance) {
-    throw new ChallengeServiceError(
-      'Your linked Prizeversity classroom is not currently active.',
-      'REWARD_LINK_REQUIRED',
-      403
-    );
-  }
-  return user;
+  return { user, instanceIds };
 };
 
-const findActiveAssignment = async (
+const findActiveAssignments = async (
   challengeId: Types.ObjectId,
-  rewardIntegrationInstanceId: Types.ObjectId
-): Promise<IChallengeAssignmentDocument | null> => {
-  return ChallengeAssignment.findOne({
+  rewardIntegrationInstanceIds: Types.ObjectId[],
+  assignmentId?: string
+): Promise<IChallengeAssignmentDocument[]> => {
+  if (assignmentId && !Types.ObjectId.isValid(assignmentId)) return [];
+
+  return ChallengeAssignment.find({
+    ...(assignmentId ? { _id: new Types.ObjectId(assignmentId) } : {}),
     challengeId,
-    rewardIntegrationInstanceId,
+    rewardIntegrationInstanceId: { $in: rewardIntegrationInstanceIds },
     ...isPublishedAssignmentNowQuery(),
-  });
+  }).sort({ publishedAt: -1, createdAt: -1 });
+};
+
+const selectAssignmentForUser = async (
+  assignments: IChallengeAssignmentDocument[],
+  userId: string,
+  assignmentId?: string
+): Promise<IChallengeAssignmentDocument | null> => {
+  if (assignments.length === 0) return null;
+  if (assignmentId || assignments.length === 1) return assignments[0];
+
+  const recentProgress = await ChallengeProgress.findOne({
+    userId: new Types.ObjectId(userId),
+    assignmentId: { $in: assignments.map((assignment) => assignment._id) },
+  }).sort({ updatedAt: -1 });
+  if (!recentProgress?.assignmentId) return assignments[0];
+
+  return (
+    assignments.find(
+      (assignment) => assignment._id.toString() === recentProgress.assignmentId?.toString()
+    ) || assignments[0]
+  );
 };
 
 const ensureAssignedChallenge = async (
   slug: string,
-  userId?: string
+  userId?: string,
+  assignmentId?: string
 ): Promise<AssignedChallengeContext> => {
-  const user = await ensureLinkedChallengeUser(userId);
+  const { user, instanceIds } = await ensureLinkedChallengeUser(userId);
   const challenge = await Challenge.findOne({
     slug: slugify(slug),
     status: 'published',
@@ -556,10 +616,8 @@ const ensureAssignedChallenge = async (
     throw new ChallengeServiceError('Challenge not found.', 'CHALLENGE_NOT_FOUND', 404);
   }
 
-  const assignment = await findActiveAssignment(
-    challenge._id,
-    user.rewardIntegrationInstanceId as Types.ObjectId
-  );
+  const assignments = await findActiveAssignments(challenge._id, instanceIds, assignmentId);
+  const assignment = await selectAssignmentForUser(assignments, user._id.toString(), assignmentId);
   if (!assignment) {
     throw new ChallengeServiceError(
       'This challenge is not available in your classroom.',
@@ -567,19 +625,25 @@ const ensureAssignedChallenge = async (
       404
     );
   }
-  return { challenge, assignment, user };
+  return {
+    challenge,
+    assignment,
+    user,
+    classroom: await getChallengeClassroomSummary(assignment),
+  };
 };
 
 const ensureAssignedCipheredSealChallenge = async (
   routeKey: string,
-  userId: string
+  userId: string,
+  assignmentId?: string
 ): Promise<AssignedChallengeContext> => {
   const normalizedRouteKey = cleanString(routeKey);
   if (!/^\d{4,12}$/.test(normalizedRouteKey)) {
     throw new ChallengeServiceError('Challenge route not found.', 'CHALLENGE_NOT_FOUND', 404);
   }
 
-  const user = await ensureLinkedChallengeUser(userId);
+  const { user, instanceIds } = await ensureLinkedChallengeUser(userId);
   const challenge = await Challenge.findOne({
     status: 'published',
     'validation.type': CIPHERED_SEAL_VALIDATOR_TYPE,
@@ -590,15 +654,18 @@ const ensureAssignedCipheredSealChallenge = async (
     throw new ChallengeServiceError('Challenge route not found.', 'CHALLENGE_NOT_FOUND', 404);
   }
 
-  const assignment = await findActiveAssignment(
-    challenge._id,
-    user.rewardIntegrationInstanceId as Types.ObjectId
-  );
+  const assignments = await findActiveAssignments(challenge._id, instanceIds, assignmentId);
+  const assignment = await selectAssignmentForUser(assignments, userId, assignmentId);
   if (!assignment) {
     throw new ChallengeServiceError('Challenge route not found.', 'CHALLENGE_NOT_FOUND', 404);
   }
 
-  return { challenge, assignment, user };
+  return {
+    challenge,
+    assignment,
+    user,
+    classroom: await getChallengeClassroomSummary(assignment),
+  };
 };
 
 const ensureChallengeById = async (challengeId: string): Promise<IChallengeDocument> => {
@@ -701,18 +768,20 @@ export const listPublishedChallenges = async (
       ? await User.findById(options.userId)
       : null;
 
-  if (!user?.rewardIntegrationInstanceId) {
+  if (!user) {
     return {
       challenges: [],
       rewardLink: await getRewardLinkSummary(options.userId),
     };
   }
 
-  const activeInstance = await RewardIntegrationInstance.exists({
-    _id: user.rewardIntegrationInstanceId,
-    active: true,
+  const memberships = await getActivePrizeversityMemberships(user, {
+    refreshStale: true,
   });
-  if (!activeInstance) {
+  const instanceIds = memberships
+    .map((membership) => membership.rewardIntegrationInstanceId)
+    .filter((instanceId): instanceId is Types.ObjectId => Boolean(instanceId));
+  if (instanceIds.length === 0) {
     return {
       challenges: [],
       rewardLink: await getRewardLinkSummary(options.userId),
@@ -720,9 +789,24 @@ export const listPublishedChallenges = async (
   }
 
   const assignments = await ChallengeAssignment.find({
-    rewardIntegrationInstanceId: user.rewardIntegrationInstanceId,
+    rewardIntegrationInstanceId: { $in: instanceIds },
     ...isPublishedAssignmentNowQuery(),
   }).sort({ publishedAt: -1, createdAt: -1 });
+  const instances = await RewardIntegrationInstance.find({
+    _id: { $in: instanceIds },
+    active: true,
+  });
+  const classroomByInstanceId = new Map<string, ChallengeClassroomSummary>(
+    instances.map((instance) => [
+      instance._id.toString(),
+      {
+        instanceId: instance._id.toString(),
+        instanceName: instance.name,
+        classroomId: instance.classroomId,
+        classroomName: instance.classroomName || undefined,
+      },
+    ])
+  );
   const challengeQuery: Record<string, unknown> = {
     _id: { $in: assignments.map((assignment) => assignment.challengeId) },
     status: 'published',
@@ -753,7 +837,8 @@ export const listPublishedChallenges = async (
       return toPublicChallengeDto(
         challenge,
         assignment,
-        progressByAssignmentId.get(assignment._id.toString()) || null
+        progressByAssignmentId.get(assignment._id.toString()) || null,
+        classroomByInstanceId.get(assignment.rewardIntegrationInstanceId.toString())
       );
     }),
     rewardLink: await getRewardLinkSummary(options.userId),
@@ -762,64 +847,87 @@ export const listPublishedChallenges = async (
 
 export const getPublishedChallenge = async (
   slug: string,
-  userId?: string
+  userId?: string,
+  assignmentId?: string
 ): Promise<{
   challenge: ReturnType<typeof toPublicChallengeDto>;
   rewardLink: RewardLinkSummary;
 }> => {
-  const { challenge, assignment } = await ensureAssignedChallenge(slug, userId);
+  const { challenge, assignment, classroom } = await ensureAssignedChallenge(
+    slug,
+    userId,
+    assignmentId
+  );
   const progress = await ChallengeProgress.findOne({
     userId: new Types.ObjectId(userId as string),
     assignmentId: assignment._id,
   });
 
   return {
-    challenge: toPublicChallengeDto(challenge, assignment, progress || null),
+    challenge: toPublicChallengeDto(challenge, assignment, progress || null, classroom),
     rewardLink: await getRewardLinkSummary(userId, getAssignmentScopeId(assignment)),
   };
 };
 
 export const getChallengeProgress = async (
   slug: string,
-  userId: string
+  userId: string,
+  assignmentId?: string
 ): Promise<{
   challenge: ReturnType<typeof toPublicChallengeDto>;
   progress: ReturnType<typeof toProgressDto>;
 }> => {
-  const { challenge, assignment } = await ensureAssignedChallenge(slug, userId);
+  const { challenge, assignment, classroom } = await ensureAssignedChallenge(
+    slug,
+    userId,
+    assignmentId
+  );
   const progress = await ChallengeProgress.findOne({
     userId: new Types.ObjectId(userId),
     assignmentId: assignment._id,
   });
 
   return {
-    challenge: toPublicChallengeDto(challenge, assignment),
+    challenge: toPublicChallengeDto(challenge, assignment, undefined, classroom),
     progress: toProgressDto(progress),
   };
 };
 
 export const startChallenge = async (
   slug: string,
-  userId: string
+  userId: string,
+  assignmentId?: string
 ): Promise<{
   challenge: ReturnType<typeof toPublicChallengeDto>;
   progress: ReturnType<typeof toProgressDto>;
 }> => {
-  const { challenge, assignment } = await ensureAssignedChallenge(slug, userId);
+  const { challenge, assignment, classroom } = await ensureAssignedChallenge(
+    slug,
+    userId,
+    assignmentId
+  );
   const progress = await getOrCreateProgress(challenge, assignment, userId);
 
   return {
-    challenge: toPublicChallengeDto(challenge, assignment),
+    challenge: toPublicChallengeDto(challenge, assignment, undefined, classroom),
     progress: toProgressDto(progress),
   };
 };
 
-const getCipheredSealPlayerContext = async (routeKey: string, userId: string) => {
-  const { challenge, assignment, user } = await ensureAssignedCipheredSealChallenge(
+const getCipheredSealPlayerContext = async (
+  routeKey: string,
+  userId: string,
+  assignmentId?: string
+) => {
+  const { challenge, assignment, user, classroom } = await ensureAssignedCipheredSealChallenge(
     routeKey,
-    userId
+    userId,
+    assignmentId
   );
-  if (assignment.reward?.enabled && !hasRewardIdentity(user)) {
+  if (
+    assignment.reward?.enabled &&
+    !(await hasRewardMembership(user, assignment.rewardIntegrationInstanceId.toString(), true))
+  ) {
     throw new ChallengeServiceError(
       'Link your Prizeversity account before entering this challenge.',
       'REWARD_LINK_REQUIRED',
@@ -828,17 +936,22 @@ const getCipheredSealPlayerContext = async (routeKey: string, userId: string) =>
   }
 
   const progress = await getOrCreateProgress(challenge, assignment, userId);
-  return { challenge, assignment, user, progress };
+  return { challenge, assignment, user, classroom, progress };
 };
 
-export const getCipheredSealRouteState = async (routeKey: string, userId: string) => {
-  const { challenge, assignment, user, progress } = await getCipheredSealPlayerContext(
+export const getCipheredSealRouteState = async (
+  routeKey: string,
+  userId: string,
+  assignmentId?: string
+) => {
+  const { challenge, assignment, user, classroom, progress } = await getCipheredSealPlayerContext(
     routeKey,
-    userId
+    userId,
+    assignmentId
   );
 
   return {
-    challenge: toPublicChallengeDto(challenge, assignment),
+    challenge: toPublicChallengeDto(challenge, assignment, undefined, classroom),
     progress: toProgressDto(progress),
     rewardLink: await getRewardLinkSummary(userId, getAssignmentScopeId(assignment)),
     protocol: buildCipheredSealPublicState(challenge, user),
@@ -848,18 +961,30 @@ export const getCipheredSealRouteState = async (routeKey: string, userId: string
 export const resolveCipheredSealRouteSeed = async (
   routeKey: string,
   userId: string,
-  seedNumber: unknown
+  seedNumber: unknown,
+  assignmentId?: string
 ) => {
-  const { challenge, user } = await getCipheredSealPlayerContext(routeKey, userId);
+  const { challenge, user } = await getCipheredSealPlayerContext(routeKey, userId, assignmentId);
   return resolveSubmittedCipheredSealSeed(challenge, user, seedNumber);
 };
 
-const getSqlInjectionPlayerContext = async (slug: string, userId: string) => {
-  const { challenge, assignment, user } = await ensureAssignedChallenge(slug, userId);
+const getSqlInjectionPlayerContext = async (
+  slug: string,
+  userId: string,
+  assignmentId?: string
+) => {
+  const { challenge, assignment, user, classroom } = await ensureAssignedChallenge(
+    slug,
+    userId,
+    assignmentId
+  );
   if (getValidatorType(challenge) !== SQL_INJECTION_VALIDATOR_TYPE) {
     throw new ChallengeServiceError('SQL sandbox not found.', 'CHALLENGE_NOT_FOUND', 404);
   }
-  if (assignment.reward?.enabled && !hasRewardIdentity(user)) {
+  if (
+    assignment.reward?.enabled &&
+    !(await hasRewardMembership(user, assignment.rewardIntegrationInstanceId.toString(), true))
+  ) {
     throw new ChallengeServiceError(
       'Link your Prizeversity account before entering this challenge.',
       'REWARD_LINK_REQUIRED',
@@ -868,21 +993,38 @@ const getSqlInjectionPlayerContext = async (slug: string, userId: string) => {
   }
 
   const progress = await getOrCreateProgress(challenge, assignment, userId);
-  return { challenge, assignment, user, progress };
+  return { challenge, assignment, user, classroom, progress };
 };
 
-export const getSqlInjectionSandboxState = async (slug: string, userId: string) => {
-  const { challenge, assignment, progress } = await getSqlInjectionPlayerContext(slug, userId);
+export const getSqlInjectionSandboxState = async (
+  slug: string,
+  userId: string,
+  assignmentId?: string
+) => {
+  const { challenge, assignment, classroom, progress } = await getSqlInjectionPlayerContext(
+    slug,
+    userId,
+    assignmentId
+  );
   return {
-    challenge: toPublicChallengeDto(challenge, assignment),
+    challenge: toPublicChallengeDto(challenge, assignment, undefined, classroom),
     progress: toProgressDto(progress),
     rewardLink: await getRewardLinkSummary(userId, getAssignmentScopeId(assignment)),
     sandbox: getSqlInjectionPublicExperience(challenge.validation),
   };
 };
 
-export const searchSqlInjectionSandbox = async (slug: string, userId: string, input: unknown) => {
-  const { challenge, user, progress } = await getSqlInjectionPlayerContext(slug, userId);
+export const searchSqlInjectionSandbox = async (
+  slug: string,
+  userId: string,
+  input: unknown,
+  assignmentId?: string
+) => {
+  const { challenge, user, progress } = await getSqlInjectionPlayerContext(
+    slug,
+    userId,
+    assignmentId
+  );
   try {
     return runSqlInjectionSandboxQuery(challenge.validation, input, {
       challenge,
@@ -898,12 +1040,19 @@ export const searchSqlInjectionSandbox = async (slug: string, userId: string, in
   }
 };
 
-const getPcapForensicsPlayerContext = async (slug: string, userId: string) => {
-  const { challenge, assignment, user } = await ensureAssignedChallenge(slug, userId);
+const getPcapForensicsPlayerContext = async (
+  slug: string,
+  userId: string,
+  assignmentId?: string
+) => {
+  const { challenge, assignment, user } = await ensureAssignedChallenge(slug, userId, assignmentId);
   if (getValidatorType(challenge) !== PCAP_FORENSICS_VALIDATOR_TYPE) {
     throw new ChallengeServiceError('Packet capture not found.', 'CHALLENGE_NOT_FOUND', 404);
   }
-  if (assignment.reward?.enabled && !hasRewardIdentity(user)) {
+  if (
+    assignment.reward?.enabled &&
+    !(await hasRewardMembership(user, assignment.rewardIntegrationInstanceId.toString(), true))
+  ) {
     throw new ChallengeServiceError(
       'Link your Prizeversity account before downloading this challenge.',
       'REWARD_LINK_REQUIRED',
@@ -912,11 +1061,19 @@ const getPcapForensicsPlayerContext = async (slug: string, userId: string) => {
   }
 
   const progress = await getOrCreateProgress(challenge, assignment, userId);
-  return { challenge, user, progress };
+  return { challenge, assignment, user, progress };
 };
 
-export const downloadPcapForensicsCapture = async (slug: string, userId: string) => {
-  const { challenge, user, progress } = await getPcapForensicsPlayerContext(slug, userId);
+export const downloadPcapForensicsCapture = async (
+  slug: string,
+  userId: string,
+  assignmentId?: string
+) => {
+  const { challenge, user, progress } = await getPcapForensicsPlayerContext(
+    slug,
+    userId,
+    assignmentId
+  );
   const experience = getPcapForensicsPublicExperience(challenge.validation);
   return {
     capture: buildPcapForensicsCapture({ challenge, progress, user }),
@@ -927,11 +1084,15 @@ export const downloadPcapForensicsCapture = async (slug: string, userId: string)
 export const submitChallenge = async (
   slug: string,
   userId: string,
-  payload: unknown
+  payload: unknown,
+  assignmentId?: string
 ): Promise<ChallengeSubmitResult> => {
-  const { challenge, assignment, user } = await ensureAssignedChallenge(slug, userId);
+  const { challenge, assignment, user } = await ensureAssignedChallenge(slug, userId, assignmentId);
 
-  if (assignment.reward?.enabled && !hasRewardIdentity(user)) {
+  if (
+    assignment.reward?.enabled &&
+    !(await hasRewardMembership(user, assignment.rewardIntegrationInstanceId.toString(), true))
+  ) {
     throw new ChallengeServiceError(
       'Link your Prizeversity account before completing rewardable challenges.',
       'REWARD_LINK_REQUIRED',

--- a/backend/src/services/rewardIntegrationService.ts
+++ b/backend/src/services/rewardIntegrationService.ts
@@ -8,7 +8,10 @@ import RewardIntegrationLinkVerification from '../models/RewardIntegrationLinkVe
 import RewardIntegrationInstance, {
   IRewardIntegrationInstanceDocument,
 } from '../models/RewardIntegrationInstance';
-import User, { type IUserDocument } from '../models/User';
+import RewardIntegrationMembership, {
+  type IRewardIntegrationMembershipDocument,
+} from '../models/RewardIntegrationMembership';
+import type { IUserDocument } from '../models/User';
 import { sendPrizeversityLinkCode } from './emailService';
 
 const log = logger.child({ module: 'reward-integration-service' });
@@ -19,6 +22,7 @@ const MAX_LINK_CODE_ATTEMPTS = 5;
 const DEFAULT_PROVIDER = 'prizeversity';
 const DEFAULT_API_BASE_URL = 'https://www.prizeversity.com';
 const DEFAULT_SCOPES = ['users:read', 'users:match', 'reward:grant'];
+const MEMBERSHIP_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
 export interface PublicRewardIntegrationInstance {
   id: string;
@@ -73,19 +77,42 @@ export interface PrizeversityLinkedAccount {
   lastSyncedAt?: Date | null;
 }
 
+export interface PublicRewardIntegrationMembership {
+  id: string;
+  instanceId: string;
+  instanceName?: string;
+  classroomId: string;
+  classroomName?: string;
+  userId: string;
+  email?: string;
+  matchedName?: string;
+  shortId?: string;
+  active: boolean;
+  disabledByUser: boolean;
+  linkedAt: Date;
+  lastVerifiedAt?: Date | null;
+  lastVerificationError?: string;
+}
+
 export interface PrizeversityStatus {
   configured: boolean;
   linked: boolean;
   missingConfig: string[];
   account: PrizeversityLinkedAccount | null;
+  memberships: PublicRewardIntegrationMembership[];
   instances: PublicRewardIntegrationInstance[];
 }
 
-export interface PrizeversityLinkVerificationStart {
-  verificationRequired: true;
-  maskedEmail: string;
-  expiresAt: Date;
-}
+export type PrizeversityLinkVerificationStart =
+  | {
+      verificationRequired: true;
+      maskedEmail: string;
+      expiresAt: Date;
+    }
+  | {
+      verificationRequired: false;
+      membership: PublicRewardIntegrationMembership;
+    };
 
 interface PrizeversityUserListResponse {
   classroomId: string;
@@ -506,32 +533,202 @@ const getInstanceConfigForClassroom = async (
   return getInstanceConfigById();
 };
 
+const toPublicMembership = (
+  membership: IRewardIntegrationMembershipDocument,
+  instance?: PublicRewardIntegrationInstance
+): PublicRewardIntegrationMembership => ({
+  id: String(membership._id),
+  instanceId: membership.instanceKey,
+  instanceName: instance?.name,
+  classroomId: membership.classroomId,
+  classroomName: instance?.classroomName,
+  userId: membership.prizeversityUserId,
+  email: membership.email,
+  matchedName: membership.matchedName,
+  shortId: membership.shortId,
+  active: membership.active,
+  disabledByUser: membership.disabledByUser,
+  linkedAt: membership.linkedAt,
+  lastVerifiedAt: membership.lastVerifiedAt,
+  lastVerificationError: membership.lastVerificationError,
+});
+
+const ensureLegacyMembership = async (user: IUserDocument): Promise<void> => {
+  if (!user.prizeversityUserId || !user.prizeversityClassroomId) return;
+
+  const configuredInstance = await getInstanceConfigForClassroom(
+    user.prizeversityClassroomId,
+    user.rewardIntegrationInstanceId?.toString()
+  );
+  if (!configuredInstance) return;
+
+  const existing = await RewardIntegrationMembership.exists({
+    awsUserId: user._id,
+    instanceKey: configuredInstance.id,
+  });
+  if (existing) return;
+
+  try {
+    await RewardIntegrationMembership.findOneAndUpdate(
+      { awsUserId: user._id, instanceKey: configuredInstance.id },
+      {
+        $set: {
+          rewardIntegrationInstanceId:
+            configuredInstance.source === 'database'
+              ? new Types.ObjectId(configuredInstance.id)
+              : null,
+          prizeversityUserId: user.prizeversityUserId,
+          classroomId: user.prizeversityClassroomId,
+          email: user.prizeversityEmail,
+          matchedName: user.prizeversityMatchedName,
+          shortId: user.prizeversityShortId,
+          active: true,
+          disabledByUser: false,
+          lastVerifiedAt: user.prizeversityLastSyncedAt || user.prizeversityLinkedAt || new Date(),
+          inactiveAt: null,
+        },
+        $setOnInsert: {
+          linkedAt: user.prizeversityLinkedAt || new Date(),
+        },
+      },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+  } catch (error: unknown) {
+    log.warn('unable to migrate legacy Prizeversity link to classroom membership.', {
+      userId: String(user._id),
+      instanceId: configuredInstance.id,
+      error: error instanceof Error ? error.message : error,
+    });
+  }
+};
+
+const refreshMembership = async (
+  membership: IRewardIntegrationMembershipDocument,
+  force = false
+): Promise<IRewardIntegrationMembershipDocument> => {
+  if (membership.disabledByUser) return membership;
+
+  const lastVerifiedAt = membership.lastVerifiedAt?.getTime() || 0;
+  if (!force && Date.now() - lastVerifiedAt < MEMBERSHIP_REFRESH_INTERVAL_MS) {
+    return membership;
+  }
+
+  const config = await getInstanceConfigById(membership.instanceKey);
+  if (!config) {
+    membership.active = false;
+    membership.inactiveAt = membership.inactiveAt || new Date();
+    membership.lastVerificationError = 'The classroom integration is not active.';
+    membership.lastVerifiedAt = new Date();
+    await membership.save();
+    return membership;
+  }
+
+  try {
+    const response = await usersList(config);
+    const classroomMember = (response.users || []).find(
+      (candidate) => String(candidate.userId) === membership.prizeversityUserId
+    );
+
+    membership.lastVerifiedAt = new Date();
+    if (!classroomMember) {
+      membership.active = false;
+      membership.inactiveAt = membership.inactiveAt || new Date();
+      membership.lastVerificationError = 'This account is no longer in the classroom roster.';
+    } else {
+      membership.active = true;
+      membership.inactiveAt = null;
+      membership.lastVerificationError = undefined;
+      membership.classroomId = config.classroomId;
+      membership.email = classroomMember.email || membership.email;
+      membership.matchedName =
+        classroomMember.name ||
+        `${classroomMember.firstName || ''} ${classroomMember.lastName || ''}`.trim() ||
+        membership.matchedName;
+      membership.shortId = classroomMember.shortId || membership.shortId;
+    }
+    await membership.save();
+  } catch (error: unknown) {
+    membership.lastVerificationError =
+      error instanceof Error ? error.message : 'Unable to verify classroom membership.';
+    await membership.save();
+  }
+
+  return membership;
+};
+
+export const getPrizeversityMemberships = async (
+  user: IUserDocument,
+  options: { refreshStale?: boolean; forceRefresh?: boolean } = {}
+): Promise<IRewardIntegrationMembershipDocument[]> => {
+  await ensureLegacyMembership(user);
+  const memberships = await RewardIntegrationMembership.find({ awsUserId: user._id }).sort({
+    linkedAt: 1,
+  });
+
+  if (!options.refreshStale && !options.forceRefresh) return memberships;
+  return Promise.all(
+    memberships.map((membership) => refreshMembership(membership, options.forceRefresh === true))
+  );
+};
+
+export const getActivePrizeversityMemberships = async (
+  user: IUserDocument,
+  options: { refreshStale?: boolean; forceRefresh?: boolean } = {}
+): Promise<IRewardIntegrationMembershipDocument[]> => {
+  const memberships = await getPrizeversityMemberships(user, options);
+  return memberships.filter((membership) => membership.active && !membership.disabledByUser);
+};
+
+export const getPrizeversityMembershipForInstance = async (
+  user: IUserDocument,
+  instanceId: string,
+  options: { forceRefresh?: boolean } = {}
+): Promise<IRewardIntegrationMembershipDocument | null> => {
+  await ensureLegacyMembership(user);
+  const membership = await RewardIntegrationMembership.findOne({
+    awsUserId: user._id,
+    instanceKey: instanceId,
+  });
+  if (!membership || membership.disabledByUser) return null;
+
+  const refreshed = await refreshMembership(membership, options.forceRefresh === true);
+  return refreshed.active ? refreshed : null;
+};
+
 export const getPrizeversityStatus = async (
   user: IUserDocument | null
 ): Promise<PrizeversityStatus> => {
   const instances = await listActiveRewardIntegrationInstances();
   const missingConfig = instances.length > 0 ? [] : getPrizeversityMissingConfig();
-  const account =
-    user?.prizeversityUserId && user.prizeversityClassroomId
-      ? {
-          instanceId:
-            user.rewardIntegrationInstanceId?.toString() ||
-            instances.find((instance) => instance.classroomId === user.prizeversityClassroomId)?.id,
-          userId: user.prizeversityUserId,
-          classroomId: user.prizeversityClassroomId,
-          email: user.prizeversityEmail,
-          matchedName: user.prizeversityMatchedName,
-          shortId: user.prizeversityShortId,
-          linkedAt: user.prizeversityLinkedAt,
-          lastSyncedAt: user.prizeversityLastSyncedAt,
-        }
-      : null;
+  const membershipDocuments = user
+    ? await getPrizeversityMemberships(user, { refreshStale: true })
+    : [];
+  const instanceById = new Map(instances.map((instance) => [instance.id, instance]));
+  const memberships = membershipDocuments.map((membership) =>
+    toPublicMembership(membership, instanceById.get(membership.instanceKey))
+  );
+  const firstActiveMembership = memberships.find(
+    (membership) => membership.active && !membership.disabledByUser
+  );
+  const account = user?.prizeversityUserId
+    ? {
+        instanceId: firstActiveMembership?.instanceId,
+        userId: user.prizeversityUserId,
+        classroomId: firstActiveMembership?.classroomId || user.prizeversityClassroomId || '',
+        email: user.prizeversityEmail,
+        matchedName: user.prizeversityMatchedName,
+        shortId: user.prizeversityShortId,
+        linkedAt: user.prizeversityLinkedAt,
+        lastSyncedAt: user.prizeversityLastSyncedAt,
+      }
+    : null;
 
   return {
     configured: instances.length > 0,
-    linked: Boolean(account),
+    linked: Boolean(firstActiveMembership),
     missingConfig,
     account,
+    memberships,
     instances,
   };
 };
@@ -699,14 +896,19 @@ export const listRewardIntegrationInstanceMembers = async (
   if (!instance) throw new PrizeversityError('Integration instance not found.');
 
   const response = await usersList(toConfig(instance));
-  const linkedUsers = await User.find({
-    rewardIntegrationInstanceId: instance._id,
+  const linkedMemberships = await RewardIntegrationMembership.find({
+    instanceKey: instanceId,
+    active: true,
+    disabledByUser: false,
     prizeversityUserId: { $in: (response.users || []).map((member) => String(member.userId)) },
   })
-    .select('_id prizeversityUserId')
+    .select('awsUserId prizeversityUserId')
     .lean();
   const awsUserByPrizeversityId = new Map(
-    linkedUsers.map((linkedUser) => [String(linkedUser.prizeversityUserId), String(linkedUser._id)])
+    linkedMemberships.map((membership) => [
+      String(membership.prizeversityUserId),
+      String(membership.awsUserId),
+    ])
   );
 
   return {
@@ -776,8 +978,9 @@ const resolvePrizeversityAccount = async (
   }
 
   if (!matchedAccount) {
+    const classroomLabel = config.classroomName || config.name;
     throw new PrizeversityError(
-      `No Prizeversity classroom member matched ${options.identifier || getUserDisplayName(user)}.`
+      `No Prizeversity member matched ${options.identifier || getUserDisplayName(user)} in ${classroomLabel}. Join that exact classroom, then try again.`
     );
   }
 
@@ -787,9 +990,52 @@ const resolvePrizeversityAccount = async (
 const applyPrizeversityLink = async (
   user: IUserDocument,
   matchedAccount: PrizeversityLinkedAccount,
+  instanceKey: string,
   rewardIntegrationInstanceId?: Types.ObjectId | null
-): Promise<PrizeversityLinkedAccount> => {
+): Promise<{
+  account: PrizeversityLinkedAccount;
+  membership: IRewardIntegrationMembershipDocument;
+}> => {
   const now = new Date();
+
+  const conflictingMembership = await RewardIntegrationMembership.findOne({
+    instanceKey,
+    prizeversityUserId: matchedAccount.userId,
+    awsUserId: { $ne: user._id },
+  });
+  if (conflictingMembership) {
+    throw new PrizeversityError(
+      'This Prizeversity classroom member is already connected to another AWS Student Hub account.',
+      409
+    );
+  }
+
+  const membership = await RewardIntegrationMembership.findOneAndUpdate(
+    { awsUserId: user._id, instanceKey },
+    {
+      $set: {
+        rewardIntegrationInstanceId: rewardIntegrationInstanceId || null,
+        prizeversityUserId: matchedAccount.userId,
+        classroomId: matchedAccount.classroomId,
+        email: matchedAccount.email,
+        matchedName: matchedAccount.matchedName,
+        shortId: matchedAccount.shortId,
+        active: true,
+        disabledByUser: false,
+        lastVerifiedAt: now,
+        lastVerificationError: undefined,
+        inactiveAt: null,
+      },
+      $setOnInsert: {
+        linkedAt: now,
+      },
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+  if (!membership) {
+    throw new PrizeversityError('Unable to save the Prizeversity classroom connection.', 500);
+  }
+
   user.rewardIntegrationInstanceId = rewardIntegrationInstanceId || null;
   user.prizeversityUserId = matchedAccount.userId;
   user.prizeversityClassroomId = matchedAccount.classroomId;
@@ -801,9 +1047,13 @@ const applyPrizeversityLink = async (
   await user.save();
 
   return {
-    ...matchedAccount,
-    linkedAt: user.prizeversityLinkedAt,
-    lastSyncedAt: user.prizeversityLastSyncedAt,
+    account: {
+      ...matchedAccount,
+      instanceId: instanceKey,
+      linkedAt: user.prizeversityLinkedAt,
+      lastSyncedAt: user.prizeversityLastSyncedAt,
+    },
+    membership,
   };
 };
 
@@ -812,6 +1062,29 @@ export const startPrizeversityAccountLink = async (
   options: { identifier?: string; instanceId?: string } = {}
 ): Promise<PrizeversityLinkVerificationStart> => {
   const { config, matchedAccount } = await resolvePrizeversityAccount(user, options);
+
+  if (user.prizeversityUserId) {
+    if (user.prizeversityUserId !== matchedAccount.userId) {
+      throw new PrizeversityError(
+        'This classroom member does not match your verified Prizeversity identity. Use the same Prizeversity account or remove all classroom connections first.',
+        409
+      );
+    }
+
+    const rewardIntegrationInstanceId =
+      config.source === 'database' ? new Types.ObjectId(config.id) : null;
+    const applied = await applyPrizeversityLink(
+      user,
+      matchedAccount,
+      config.id,
+      rewardIntegrationInstanceId
+    );
+    return {
+      verificationRequired: false,
+      membership: toPublicMembership(applied.membership, config),
+    };
+  }
+
   const email = cleanPastedValue(matchedAccount.email).toLowerCase();
 
   if (!email) {
@@ -830,6 +1103,7 @@ export const startPrizeversityAccountLink = async (
     { awsUserId: user._id },
     {
       awsUserId: user._id,
+      instanceKey: config.id,
       rewardIntegrationInstanceId,
       prizeversityUserId: matchedAccount.userId,
       classroomId: matchedAccount.classroomId,
@@ -903,17 +1177,20 @@ export const verifyPrizeversityAccountLink = async (
   const account = await applyPrizeversityLink(
     user,
     {
+      instanceId:
+        pending.instanceKey || pending.rewardIntegrationInstanceId?.toString() || undefined,
       userId: pending.prizeversityUserId,
       classroomId: pending.classroomId,
       email: pending.email,
       matchedName: pending.matchedName,
       shortId: pending.shortId,
     },
+    pending.instanceKey || pending.rewardIntegrationInstanceId?.toString() || 'env',
     pending.rewardIntegrationInstanceId || null
   );
 
   await pending.deleteOne();
-  return account;
+  return account.account;
 };
 
 export const linkPrizeversityAccount = async (
@@ -923,11 +1200,64 @@ export const linkPrizeversityAccount = async (
   const { config, matchedAccount } = await resolvePrizeversityAccount(user, options);
   const rewardIntegrationInstanceId =
     config.source === 'database' ? new Types.ObjectId(config.id) : null;
-  return applyPrizeversityLink(user, matchedAccount, rewardIntegrationInstanceId);
+  const applied = await applyPrizeversityLink(
+    user,
+    matchedAccount,
+    config.id,
+    rewardIntegrationInstanceId
+  );
+  return applied.account;
+};
+
+const syncLegacyClassroomPointer = async (user: IUserDocument): Promise<void> => {
+  const fallbackMembership = await RewardIntegrationMembership.findOne({
+    awsUserId: user._id,
+    active: true,
+    disabledByUser: false,
+  }).sort({ linkedAt: 1 });
+
+  user.rewardIntegrationInstanceId = fallbackMembership?.rewardIntegrationInstanceId || null;
+  user.prizeversityClassroomId = fallbackMembership?.classroomId;
+  user.prizeversityLastSyncedAt =
+    fallbackMembership?.lastVerifiedAt || user.prizeversityLastSyncedAt;
+  await user.save();
+};
+
+export const unlinkPrizeversityMembership = async (
+  user: IUserDocument,
+  instanceId: string
+): Promise<void> => {
+  const membership = await RewardIntegrationMembership.findOne({
+    awsUserId: user._id,
+    instanceKey: instanceId,
+  });
+  if (!membership) {
+    throw new PrizeversityError('Classroom connection not found.', 404);
+  }
+
+  membership.active = false;
+  membership.disabledByUser = true;
+  membership.inactiveAt = new Date();
+  membership.lastVerificationError = 'Disconnected by user.';
+  await membership.save();
+  await RewardIntegrationLinkVerification.deleteOne({
+    awsUserId: user._id,
+    instanceKey: instanceId,
+  });
+  await syncLegacyClassroomPointer(user);
+};
+
+export const deletePrizeversityAccountData = async (
+  awsUserId: Types.ObjectId | string
+): Promise<void> => {
+  await Promise.all([
+    RewardIntegrationLinkVerification.deleteMany({ awsUserId }),
+    RewardIntegrationMembership.deleteMany({ awsUserId }),
+  ]);
 };
 
 export const unlinkPrizeversityAccount = async (user: IUserDocument): Promise<void> => {
-  await RewardIntegrationLinkVerification.deleteOne({ awsUserId: user._id });
+  await deletePrizeversityAccountData(user._id);
   user.rewardIntegrationInstanceId = null;
   user.prizeversityUserId = undefined;
   user.prizeversityClassroomId = undefined;

--- a/docs-site/guide/instances.md
+++ b/docs-site/guide/instances.md
@@ -57,7 +57,7 @@ A successful check proves the key can read the configured classroom. It does not
 
 The **Students** tab reads the current roster from Prizeversity. Balance, level, and XP values shown there come from Prizeversity rather than an AWS Student Hub wallet.
 
-For each Prizeversity member, AWS Student Hub also reports whether an AWS account is linked to that Prizeversity user ID in this instance.
+For each Prizeversity member, AWS Student Hub also reports whether an AWS account has an active membership for that Prizeversity user ID in this instance.
 
 ## Updating credentials
 
@@ -70,11 +70,11 @@ Leave the API key field blank when changing unrelated metadata. The existing key
 Deactivating an instance:
 
 - Prevents new challenge assignments from being created or published
-- Removes its assigned challenges from linked students
+- Removes its assigned challenges from students connected to that instance
 - Prevents it from being selected for new account links
 - Prevents normal reward delivery through that instance
 
-It does not delete assignments, student links, submissions, progress, or prior reward emissions. Reactivation restores eligibility, subject to assignment status and dates.
+It does not delete assignments, student memberships, submissions, progress, or prior reward emissions. Reactivation restores eligibility, subject to roster membership, assignment status, and dates.
 
 ## Environment fallback
 

--- a/docs-site/guide/roles-and-permissions.md
+++ b/docs-site/guide/roles-and-permissions.md
@@ -13,7 +13,7 @@ A higher role inherits the capabilities of every role below it. Backend middlewa
 | Capability                                          | Member | Moderator | Admin | Superuser |
 | --------------------------------------------------- | :----: | :-------: | :---: | :-------: |
 | Manage own profile and preferences                  |  Yes   |    Yes    |  Yes  |    Yes    |
-| Link a Prizeversity classroom account               |  Yes   |    Yes    |  Yes  |    Yes    |
+| Verify Prizeversity identity and connect classrooms |  Yes   |    Yes    |  Yes  |    Yes    |
 | View, start, and submit assigned challenges         |  Yes   |    Yes    |  Yes  |    Yes    |
 | View dashboard statistics and user details          |   No   |    Yes    |  Yes  |    Yes    |
 | Ban or unban a lower-role account                   |   No   |    Yes    |  Yes  |    Yes    |
@@ -26,9 +26,9 @@ A higher role inherits the capabilities of every role below it. Backend middlewa
 
 ## Member
 
-`member` is the default role for students and general site users. Members manage their own account, link a Prizeversity identity, and participate in challenges assigned to that linked classroom.
+`member` is the default role for students and general site users. Members manage their own account, verify a Prizeversity identity, connect one or more configured classrooms, and participate in challenges assigned to those classrooms.
 
-A member cannot open protected administration routes. Challenge access is still determined by the linked instance and assignment state, not by role alone.
+A member cannot open protected administration routes. Challenge access is still determined by active classroom membership and assignment state, not by role alone.
 
 ## Moderator
 

--- a/docs-site/guide/semester-runbook.md
+++ b/docs-site/guide/semester-runbook.md
@@ -114,6 +114,6 @@ For a new semester or section:
 2. Create a new AWS Student Hub instance with that classroom's API key.
 3. Reuse catalog definitions by assigning them to the new instance.
 4. Configure new dates, limits, and rewards.
-5. Require students to link to the new classroom instance.
+5. Require students to join the new Prizeversity classroom and add that classroom in AWS Student Hub Account Settings. Existing verified identities do not replace or disconnect prior classes.
 
 Do not rename an old instance and replace its classroom credentials merely to reuse the UI. A new instance preserves clean classroom and reward history.

--- a/docs-site/guide/student-linking.md
+++ b/docs-site/guide/student-linking.md
@@ -1,18 +1,18 @@
 # Student account linking
 
-Account linking establishes which Prizeversity classroom and member receive a student's challenge rewards. It is also the boundary used to determine which challenge assignments the student can see.
+Account linking verifies one Prizeversity identity and records every configured classroom in which that identity is a member. Classroom memberships determine which challenge assignments the student can see and where each completion reward is delivered.
 
 ## What is linked
 
-One AWS Student Hub user can have one active Prizeversity link at a time. The link records:
+One AWS Student Hub user has one verified Prizeversity identity and may have multiple classroom memberships. The identity records the Prizeversity user ID, email, display name, short ID, and initial verification time. Each membership separately records:
 
 - AWS reward integration instance
 - Prizeversity classroom ID
-- Prizeversity user ID
-- Prizeversity email, display name, and short ID when available
-- Initial link and latest synchronization timestamps
+- Prizeversity member identity observed in that roster
+- Active or disconnected state
+- Initial connection and latest roster-verification timestamps
 
-A student who changes sections must unlink the old account and link to the new instance.
+A student does not replace an old classroom when joining another one. The student adds the new classroom connection, and progress remains isolated by classroom assignment.
 
 ## Student workflow
 
@@ -20,11 +20,14 @@ A student who changes sections must unlink the old account and link to the new i
 2. Open **Account Settings** and find **Prizeversity Rewards**.
 3. Select the correct reward classroom when multiple instances are available.
 4. Enter a Prizeversity email, exact full name, short ID, or user ID. Leaving the field blank makes AWS Student Hub try the student's own account details.
-5. Select **Send code**.
+5. Select **Send code** for the first classroom.
 6. Retrieve the six-digit code from the email address stored on the matched Prizeversity account.
-7. Enter the code to complete the link.
+7. Enter the code to verify the identity and connect the classroom.
+8. To add another class, join it in Prizeversity, return to Account Settings, select the additional classroom, and choose **Connect classroom**.
 
 The code expires after 10 minutes. Five incorrect attempts invalidate the pending request and require a new code.
+
+After the first successful verification, an additional classroom can connect without another code only when its roster resolves to the same Prizeversity user ID. A different identity is rejected rather than silently replacing the verified account.
 
 ## Why email verification is required
 
@@ -36,7 +39,22 @@ The code is stored only as a salted SHA-256 hash. A new request replaces the pre
 
 AWS Student Hub first reads the selected classroom roster and looks for an exact case-insensitive match against user ID, short ID, email, or full name. If roster lookup does not produce a match, it falls back to Prizeversity's user-matching endpoint using the supplied identifier and the AWS user's account data.
 
-The selected instance determines the classroom searched. A valid member in another classroom is not a valid match.
+The selected instance determines the classroom searched. A valid member in another classroom is not a valid match. The student must first join the exact Prizeversity classroom represented by that instance.
+
+For example, membership in `CIS Test2` cannot satisfy an AWS Student Hub instance configured for `CIS Test`, even when both classrooms belong to the same instructor.
+
+## Membership lifecycle
+
+AWS Student Hub periodically rechecks each connected membership against its Prizeversity classroom roster.
+
+- Joining a new class does not connect it automatically; the student explicitly adds the configured classroom in Account Settings.
+- Leaving one class marks only that membership inactive after revalidation. The student's other classrooms continue working.
+- Rejoining an available class allows the student to reconnect it using the same verified identity.
+- Leaving every class does not erase the verified identity, progress, submissions, or reward history.
+- **Disconnect classroom** disables one membership by user choice.
+- **Remove identity and all classrooms** clears the identity and every membership, requiring email verification again later.
+
+Challenge detail, progress, attempts, and rewards are resolved by assignment ID. If the same catalog challenge is assigned to two classrooms, each assignment has independent progress and uses that classroom's API credentials.
 
 ## Required email state
 
@@ -44,11 +62,11 @@ The matched Prizeversity account must have an email address. Linking cannot be c
 
 SMTP must also be correctly configured on the AWS Student Hub backend. A successful Prizeversity match followed by an email delivery failure is reported separately from “no member found.”
 
-## Unlinking
+## Disconnecting and removing identity
 
-Students can unlink from the connected panel in Account Settings. Unlinking removes the AWS-to-Prizeversity identity fields and any pending verification request.
+Use **Disconnect classroom** when a student should stop using one class but retain other classroom connections. Use **Remove identity and all classrooms** only when the entire Prizeversity identity is wrong or must be replaced.
 
-Unlinking does not erase completed challenge progress or reverse rewards already sent. Until another account is linked, the student sees no classroom-assigned challenges.
+Neither action erases completed challenge progress or reverses rewards already sent. A disconnected classroom no longer contributes visible assignments and cannot receive new rewards.
 
 ## Instructor diagnosis
 
@@ -56,9 +74,9 @@ When a student cannot link, check in this order:
 
 1. Confirm the intended instance is active.
 2. Run **Check connection**.
-3. Find the member in the instance's **Students** tab.
+3. Find the member in the instance's **Students** tab. Similar classroom names are not interchangeable.
 4. Confirm the member has a valid email address.
-5. Confirm the student selected the correct classroom.
+5. Confirm the student selected the exact classroom they joined in Prizeversity.
 6. Ask for the exact Prizeversity email or short ID, not a nickname.
 7. If the message says email delivery failed, inspect backend SMTP configuration rather than changing the member identifier.
 

--- a/docs-site/guide/system-overview.md
+++ b/docs-site/guide/system-overview.md
@@ -2,10 +2,11 @@
 
 This guide is for instructors and operators who have the AWS Student Hub `admin` or `superuser` role. It explains the system in operational terms without requiring knowledge of MongoDB, Express, or the frontend implementation.
 
-## The four records that matter
+## The five records that matter
 
 <div class="doc-model">
   <div><strong>Instance</strong><span>The AWS Student Hub connection to one Prizeversity classroom.</span></div>
+  <div><strong>Membership</strong><span>One verified student identity connected to one instance roster.</span></div>
   <div><strong>Definition</strong><span>A reusable challenge in the global catalog.</span></div>
   <div><strong>Assignment</strong><span>A definition configured for one instance.</span></div>
   <div><strong>Progress</strong><span>One student's work for one assignment.</span></div>
@@ -16,6 +17,10 @@ This guide is for instructors and operators who have the AWS Student Hub `admin`
 An instance represents exactly one Prizeversity classroom. It stores the classroom ID, a server-side API key, the expected API scopes, connection status, and a cached roster count.
 
 If an instructor runs two sections of the same course, create two instances. Do not reuse one instance across multiple Prizeversity classrooms.
+
+### Student membership
+
+A student verifies one Prizeversity identity, then connects each configured classroom they have joined. One student may therefore have several active memberships. Each membership is independently revalidated against its classroom roster and controls that classroom's challenge visibility and rewards.
 
 ### Catalog definition
 
@@ -46,10 +51,10 @@ Progress belongs to a student and an assignment, not merely to a student and a c
 
 A student can see a challenge only when every condition below is true:
 
-1. The student has linked a Prizeversity account.
-2. The linked AWS account points to an active instance.
+1. The student has verified a Prizeversity identity.
+2. The student has an active roster membership for the instance.
 3. The catalog definition is published.
-4. That definition has an assignment for the student's instance.
+4. That definition has an assignment for one of the student's connected instances.
 5. The assignment is published.
 6. The current time is inside the assignment's opening and closing window.
 

--- a/docs-site/reference/architecture.md
+++ b/docs-site/reference/architecture.md
@@ -16,12 +16,13 @@ AWS Student Hub does not maintain a second wallet. It sends a completion reward 
 
 <div class="doc-model">
   <div><strong>RewardIntegrationInstance</strong><span>Maps server-side credentials to one Prizeversity classroom.</span></div>
+  <div><strong>RewardIntegrationMembership</strong><span>Maps one verified AWS user to one instance roster membership.</span></div>
   <div><strong>ChallengeAssignment</strong><span>Maps one published definition to one instance.</span></div>
   <div><strong>ChallengeProgress</strong><span>Maps one user to one assignment.</span></div>
   <div><strong>RewardIntegrationEmission</strong><span>Records one external reward attempt and response.</span></div>
 </div>
 
-`ChallengeAssignment` also references `Challenge`. `User` references the selected reward instance and external Prizeversity identity. `ChallengeSubmission` references the user, definition, assignment, and progress record.
+`ChallengeAssignment` also references `Challenge`. `User` retains the verified external Prizeversity identity, while `RewardIntegrationMembership` records each classroom connection. Legacy single-instance fields remain as a compatibility pointer. `ChallengeSubmission` references the user, definition, assignment, and progress record.
 
 ## Application layers
 
@@ -50,20 +51,20 @@ The React application renders the global catalog, instance workspace, student ch
 `GET /challenges` follows this path:
 
 1. Resolve the authenticated AWS user when available.
-2. Require a stored reward instance link.
-3. Confirm the instance exists and is active.
-4. Load published assignments in the current availability window for that instance.
+2. Load the user's active Prizeversity classroom memberships.
+3. Revalidate stale memberships and retain only active configured instances.
+4. Load published assignments in the current availability window for all connected instances.
 5. Load only published definitions referenced by those assignments.
 6. Load progress by user and assignment.
-7. Return assignment values for reward, dates, and attempts alongside reusable definition content.
+7. Return assignment values and classroom context for reward, dates, and attempts alongside reusable definition content.
 
-The response does not expose assignments belonging to another instance.
+The response does not expose assignments belonging to an instance the student has not connected. When one definition is assigned to multiple connected classrooms, each assignment is returned separately and carries its assignment ID.
 
 ## Submission flow
 
 `POST /challenges/:slug/submit` performs:
 
-1. Linked-user and active-instance enforcement.
+1. Verified user, active membership, and assignment-instance enforcement.
 2. Published definition and active assignment resolution.
 3. Reward identity enforcement for rewardable assignments.
 4. Progress creation or retrieval by user and assignment.
@@ -90,7 +91,8 @@ If no active database-backed instances exist, the reward service can expose one 
 
 ## Important implementation constraints
 
-- An AWS user links to one instance at a time.
+- An AWS user has one verified Prizeversity identity and may connect multiple classroom instances.
+- Each connected instance must resolve to the same verified Prizeversity user ID.
 - One definition may be assigned at most once to a given instance.
 - One progress record exists per user and assignment.
 - One completion event exists per user and assignment.

--- a/docs-site/reference/data-model.md
+++ b/docs-site/reference/data-model.md
@@ -56,9 +56,25 @@ Server-side Prizeversity classroom connection.
 
 The model records `createdBy`, but service authorization currently does not scope records to their creator.
 
-## User link fields
+## RewardIntegrationMembership
 
-The user record stores one linked reward identity:
+Classroom-specific link between one AWS Student Hub user and one Prizeversity instance.
+
+| Field                         | Purpose                                                    |
+| ----------------------------- | ---------------------------------------------------------- |
+| `awsUserId`, `instanceKey`    | Membership identity; unique together.                      |
+| `rewardIntegrationInstanceId` | Database-backed instance reference when available.         |
+| `prizeversityUserId`          | Verified external identity found in this classroom roster. |
+| `classroomId`                 | External classroom scope.                                  |
+| `active`, `disabledByUser`    | Roster state and explicit student disconnect state.        |
+| `linkedAt`, `lastVerifiedAt`  | Connection and roster-check timestamps.                    |
+| `lastVerificationError`       | Reason an inactive membership cannot currently be used.    |
+
+Unique indexes prevent duplicate user-instance links and prevent one Prizeversity classroom member from being connected to multiple AWS Student Hub users.
+
+## User identity fields
+
+The user record stores the verified global Prizeversity identity:
 
 - `rewardIntegrationInstanceId`
 - `prizeversityUserId`
@@ -69,7 +85,7 @@ The user record stores one linked reward identity:
 - `prizeversityLinkedAt`
 - `prizeversityLastSyncedAt`
 
-These fields are cleared on unlink. Historical progress retains its assignment and instance references.
+`rewardIntegrationInstanceId` and `prizeversityClassroomId` are retained as compatibility pointers to an active membership. Runtime authorization uses `RewardIntegrationMembership`. Removing the complete identity clears these fields and all memberships; disconnecting one classroom only changes that membership. Historical progress retains its assignment and instance references.
 
 ## RewardIntegrationLinkVerification
 
@@ -78,6 +94,7 @@ Temporary ownership challenge for account linking.
 | Field                         | Purpose                                      |
 | ----------------------------- | -------------------------------------------- |
 | `awsUserId`                   | One pending request per AWS user.            |
+| `instanceKey`                 | Selected database or environment instance.   |
 | `rewardIntegrationInstanceId` | Selected classroom instance.                 |
 | Prizeversity identity fields  | The matched member awaiting ownership proof. |
 | `codeHash`, `codeSalt`        | Non-plaintext verification material.         |

--- a/docs-site/reference/deployment.md
+++ b/docs-site/reference/deployment.md
@@ -55,6 +55,10 @@ The migration is idempotent. It:
 
 Run it once for every existing environment. A new empty environment using current models does not require legacy records to be converted.
 
+## Classroom membership compatibility
+
+Deployments created before multi-classroom linking stored one instance pointer directly on each user. The current reward service converts that legacy pointer into a `RewardIntegrationMembership` the next time the user's Prizeversity status or challenge access is loaded. No separate destructive migration is required. Keep the legacy user fields during this compatibility period; runtime authorization and reward delivery use the membership record.
+
 ## Curated challenge registration
 
 Seeding is environment-specific because catalog definitions live in MongoDB. Examples:
@@ -104,9 +108,9 @@ After deployment, verify:
 1. Admin and superuser access to catalog and instances.
 2. Instance connection against a non-sensitive roster account.
 3. Link-code delivery through production SMTP.
-4. A student's classroom-specific challenge list.
+4. A student's combined challenge list across two connected classrooms.
 5. Correct submission and manual review behavior.
-6. Exactly one Prizeversity reward.
+6. Exactly one Prizeversity reward delivered through the assignment's classroom instance.
 7. Reward emission status and external balance agreement.
 8. Archived assignments remain hidden but retain history.
 

--- a/docs-site/reference/glossary.md
+++ b/docs-site/reference/glossary.md
@@ -40,17 +40,21 @@ AWS Student Hub's server-side connection to one Prizeversity classroom, includin
 
 Validation outcome in which proof is stored as pending until an admin approves or rejects it.
 
+## Membership
+
+Roster-verified connection between one AWS Student Hub user and one Prizeversity classroom instance. One verified identity may have multiple memberships.
+
 ## Progress
 
 Current challenge state for one AWS user and one classroom assignment.
 
 ## Prizeversity link
 
-Verified mapping from one AWS user to one Prizeversity member and reward instance.
+Verified Prizeversity identity plus one or more classroom memberships for an AWS user.
 
 ## Published
 
-Eligible for use, not automatically visible. Student visibility still requires an active link, instance, definition, assignment, and availability window.
+Eligible for use, not automatically visible. Student visibility still requires an active classroom membership, instance, definition, assignment, and availability window.
 
 ## Reward instance
 

--- a/docs-site/reference/http-api.md
+++ b/docs-site/reference/http-api.md
@@ -32,7 +32,7 @@ Error responses generally contain `error`. Challenge-domain errors also include 
 
 ### `GET /integrations/prizeversity/status`
 
-Returns active instances, configuration state, and the current user's linked account.
+Returns active instances, the verified Prizeversity identity, and all active, inactive, or explicitly disconnected classroom memberships.
 
 ### `POST /integrations/prizeversity/link`
 
@@ -47,7 +47,7 @@ Starts verified linking.
 
 `identifier` may be omitted. `instanceId` should be supplied when the user selects among multiple classrooms.
 
-Successful response includes `verificationRequired`, a masked destination email, and `expiresAt`. It does not establish the permanent link yet.
+For the first classroom, a successful response includes `verificationRequired`, a masked destination email, and `expiresAt`; it does not establish the permanent link yet. If the user already verified the same Prizeversity identity, the classroom membership is created immediately and `verificationRequired` is `false`.
 
 ### `POST /integrations/prizeversity/link/verify`
 
@@ -57,23 +57,29 @@ Successful response includes `verificationRequired`, a masked destination email,
 }
 ```
 
-Verifies the pending ownership code and stores the linked external identity.
+Verifies the pending ownership code, stores the external identity, and creates the selected classroom membership.
+
+### `DELETE /integrations/prizeversity/link/:instanceId`
+
+Disconnects one classroom membership while retaining the verified identity, other memberships, and historical challenge data.
 
 ### `DELETE /integrations/prizeversity/link`
 
-Clears the user's linked identity and pending verification request.
+Clears the user's verified identity, all classroom memberships, and any pending verification request. Historical challenge data and completed rewards are retained.
 
 ## Student challenge routes
 
 ### `GET /challenges`
 
-Returns only active assignments for the user's linked instance. An unlinked user receives an empty challenge array plus reward-link state.
+Returns active assignments across every roster-verified classroom membership. An unlinked user receives an empty challenge array plus reward-link state.
 
 Optional query filters: `tag`, `difficulty`.
 
 ### `GET /challenges/:slug`
 
-Returns one assigned challenge, assignment-specific settings, progress, and reward-link state. Challenges outside the user's classroom resolve as not found.
+Returns one assigned challenge, assignment-specific settings, progress, and reward-link state. Challenges outside the user's connected classrooms resolve as not found.
+
+When the same challenge definition is assigned to multiple connected classrooms, challenge detail, progress, start, submit, specialized lab, and download routes accept `assignmentId` as a query parameter. The backend verifies that assignment against the authenticated user's memberships; it never trusts a client-supplied classroom ID.
 
 ### `GET /challenges/:slug/progress`
 
@@ -102,7 +108,7 @@ GET  /challenges/ciphered-seal/route/:routeKey
 POST /challenges/ciphered-seal/route/:routeKey/resolve
 ```
 
-The resolve body contains `seedNumber`. Both endpoints enforce linked instance and active assignment scope.
+The resolve body contains `seedNumber`. Both endpoints enforce active membership and assignment scope.
 
 ### SQL Injection Sandbox routes
 
@@ -129,7 +135,7 @@ The response contains the executed synthetic statement, bounded result rows, tru
 }
 ```
 
-Both sandbox routes enforce authentication, active account linking, published definition state, and the student's active classroom assignment.
+Both sandbox routes enforce authentication, active classroom membership, published definition state, and the student's assignment.
 
 ### PCAP Forensics route
 
@@ -137,7 +143,7 @@ Both sandbox routes enforce authentication, active account linking, published de
 GET /challenges/:slug/pcap
 ```
 
-Returns a personalized `.pcap` file as `application/octet-stream`. The response is an authenticated, rate-limited binary download with private, no-store caching. Access enforces the student's active Prizeversity link and classroom assignment and starts progress if necessary.
+Returns a personalized `.pcap` file as `application/octet-stream`. The response is an authenticated, rate-limited binary download with private, no-store caching. Access enforces the student's active membership for the assignment classroom and starts progress if necessary.
 
 The recovered flag is submitted through the standard endpoint:
 

--- a/docs-site/reference/security.md
+++ b/docs-site/reference/security.md
@@ -48,9 +48,9 @@ SMTP availability is therefore part of the account-security boundary, not merely
 
 ## Classroom isolation
 
-Challenge access is derived from the user's stored instance ID. Services query assignments using that instance and do not accept a classroom ID supplied by the student.
+Challenge access is derived from persisted, roster-verified memberships. Services query assignments across those membership instance IDs and do not accept a classroom ID supplied by the student.
 
-Reward delivery verifies that the assignment instance matches the user's linked instance before selecting credentials and classroom ID.
+Student navigation carries an assignment ID when the same definition exists in multiple classes. The backend verifies that the assignment belongs to an active membership before loading progress. Reward delivery independently refreshes that exact membership, selects credentials from the assignment instance, and uses the classroom and Prizeversity user IDs stored on the membership.
 
 ## Validation and proof handling
 
@@ -95,7 +95,7 @@ Curated validators must decide acceptance on the backend.
 
 The HTTP reference documents the authenticated contract used by the AWS Student Hub frontend. It is not an anonymous challenge-authoring API and it does not contain stored answers, signing secrets, API keys, or student-specific solutions.
 
-Knowing an endpoint or request shape is not an authorization bypass. Student routes still enforce the signed-in user, active account status, linked Prizeversity instance, published classroom assignment, schedule, attempt limits, and backend validation. Admin routes independently reload the user's current role and require `admin` or `superuser`.
+Knowing an endpoint or request shape is not an authorization bypass. Student routes still enforce the signed-in user, active account status, roster-verified Prizeversity membership, published classroom assignment, schedule, attempt limits, and backend validation. Admin routes independently reload the user's current role and require `admin` or `superuser`.
 
 Public route documentation can reduce discovery work, so challenge integrity must never depend on an endpoint being unknown. If a challenge requires implementation details that would materially reveal its solution, keep those details in source-controlled internal notes rather than the public handbook.
 

--- a/frontend/src/challenges/cipheredSeal/CipheredSealProtocol.tsx
+++ b/frontend/src/challenges/cipheredSeal/CipheredSealProtocol.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { motion } from 'motion/react';
 import {
   ArrowLeft,
@@ -54,6 +54,8 @@ function WardSigil({ ward }: { ward: CipheredSealWard }) {
 
 function CipheredSealProtocol() {
   const { routeKey = '' } = useParams();
+  const [searchParams] = useSearchParams();
+  const requestedAssignmentId = searchParams.get('assignmentId');
   const navigate = useNavigate();
   const { user, loading: authLoading } = useAuth();
   const [state, setState] = useState<CipheredSealRouteStateResponse | null>(null);
@@ -68,11 +70,14 @@ function CipheredSealProtocol() {
   const [copied, setCopied] = useState(false);
   const [rewardModalOpen, setRewardModalOpen] = useState(false);
   const [submitReward, setSubmitReward] = useState<ChallengeSubmitResponse['reward']>();
+  const routePath = `/challenge/${routeKey}${
+    requestedAssignmentId ? `?assignmentId=${encodeURIComponent(requestedAssignmentId)}` : ''
+  }`;
 
   useEffect(() => {
     if (authLoading) return;
     if (!user) {
-      navigate(`/auth?redirect=${encodeURIComponent(`/challenge/${routeKey}`)}`, { replace: true });
+      navigate(`/auth?redirect=${encodeURIComponent(routePath)}`, { replace: true });
       return;
     }
 
@@ -80,7 +85,7 @@ function CipheredSealProtocol() {
     setLoading(true);
     setError('');
     challengeAPI
-      .getCipheredSealState(routeKey)
+      .getCipheredSealState(routeKey, requestedAssignmentId)
       .then((response) => {
         if (active) setState(response);
       })
@@ -100,7 +105,7 @@ function CipheredSealProtocol() {
     return () => {
       active = false;
     };
-  }, [authLoading, navigate, routeKey, user]);
+  }, [authLoading, navigate, requestedAssignmentId, routeKey, routePath, user]);
 
   const isCompleted = completedStatuses.has(state?.progress.status || '');
   const canInvoke = Boolean(seedResult?.resolved && seedResult.values && !isCompleted);
@@ -125,7 +130,11 @@ function CipheredSealProtocol() {
     setSequence([]);
     setRitualMessage('Awaiting invocation.');
     try {
-      const response = await challengeAPI.resolveCipheredSealSeed(routeKey, seedNumber);
+      const response = await challengeAPI.resolveCipheredSealSeed(
+        routeKey,
+        seedNumber,
+        requestedAssignmentId || state?.challenge.assignmentId
+      );
       setSeedResult(response);
     } catch (requestError: unknown) {
       setSeedResult(null);
@@ -158,7 +167,11 @@ function CipheredSealProtocol() {
     setError('');
 
     try {
-      const response = await challengeAPI.submit(state.challenge.slug, { sequence });
+      const response = await challengeAPI.submit(
+        state.challenge.slug,
+        { sequence },
+        requestedAssignmentId || state.challenge.assignmentId
+      );
       setState((current) => (current ? { ...current, progress: response.progress } : current));
       setRitualMessage(response.message);
       if (response.accepted && response.completed) {

--- a/frontend/src/challenges/sqlInjection/SqlInjectionSandbox.tsx
+++ b/frontend/src/challenges/sqlInjection/SqlInjectionSandbox.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { motion } from 'motion/react';
 import {
   ArrowLeft,
@@ -44,6 +44,8 @@ const getRewardStatus = (reward?: ChallengeSubmitResponse['reward']): string => 
 
 function SqlInjectionSandbox() {
   const { slug = '' } = useParams();
+  const [searchParams] = useSearchParams();
+  const assignmentId = searchParams.get('assignmentId');
   const navigate = useNavigate();
   const { user, loading: authLoading } = useAuth();
   const [state, setState] = useState<SqlInjectionSandboxStateResponse | null>(null);
@@ -58,11 +60,13 @@ function SqlInjectionSandbox() {
   const [copiedValue, setCopiedValue] = useState('');
   const [rewardModalOpen, setRewardModalOpen] = useState(false);
   const [submitReward, setSubmitReward] = useState<ChallengeSubmitResponse['reward']>();
+  const assignmentQuery = assignmentId ? `?assignmentId=${encodeURIComponent(assignmentId)}` : '';
+  const labPath = `/challenges/${slug}/lab${assignmentQuery}`;
 
   useEffect(() => {
     if (authLoading) return;
     if (!user) {
-      navigate(`/auth?redirect=${encodeURIComponent(`/challenges/${slug}/lab`)}`, {
+      navigate(`/auth?redirect=${encodeURIComponent(labPath)}`, {
         replace: true,
       });
       return;
@@ -72,7 +76,7 @@ function SqlInjectionSandbox() {
     setLoading(true);
     setError('');
     challengeAPI
-      .getSqlInjectionSandbox(slug)
+      .getSqlInjectionSandbox(slug, assignmentId)
       .then((response) => {
         if (active) setState(response);
       })
@@ -92,7 +96,7 @@ function SqlInjectionSandbox() {
     return () => {
       active = false;
     };
-  }, [authLoading, navigate, slug, user]);
+  }, [assignmentId, authLoading, labPath, navigate, slug, user]);
 
   const isCompleted = completedStatuses.has(state?.progress.status || '');
 
@@ -107,7 +111,11 @@ function SqlInjectionSandbox() {
     setError('');
     setSubmitMessage('');
     try {
-      const response = await challengeAPI.searchSqlInjectionSandbox(slug, searchInput);
+      const response = await challengeAPI.searchSqlInjectionSandbox(
+        slug,
+        searchInput,
+        assignmentId
+      );
       setSearchResult(response);
     } catch (requestError: unknown) {
       setError(
@@ -135,7 +143,7 @@ function SqlInjectionSandbox() {
     setError('');
     setSubmitMessage('');
     try {
-      const response = await challengeAPI.submit(slug, { flag });
+      const response = await challengeAPI.submit(slug, { flag }, assignmentId);
       setState((current) => (current ? { ...current, progress: response.progress } : current));
       setSubmitMessage(response.message);
       if (response.accepted && response.completed) {
@@ -184,7 +192,10 @@ function SqlInjectionSandbox() {
       <section className="sql-lab-shell">
         <header className="sql-lab-header">
           <div className="sql-lab-header-copy">
-            <Link to={`/challenges/${challenge.slug}`} className="sql-lab-back-link">
+            <Link
+              to={`/challenges/${challenge.slug}${assignmentQuery}`}
+              className="sql-lab-back-link"
+            >
               <ArrowLeft size={15} /> Challenge briefing
             </Link>
             <span className="sql-lab-kicker">Isolated training environment</span>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -112,6 +112,11 @@ function Navbar({ theme, toggleTheme }: LayoutProps) {
     setIsAccountDropdownOpen(!isAccountDropdownOpen);
   };
 
+  const openAuth = (mode: 'signin' | 'signup') => {
+    navigate(mode === 'signup' ? '/auth?mode=signup' : '/auth');
+    setIsMenuOpen(false);
+  };
+
   const getDisplayName = (user?: NavbarUser | null): string => {
     if (!user) return 'User';
 
@@ -201,7 +206,7 @@ function Navbar({ theme, toggleTheme }: LayoutProps) {
           <div className="auth-buttons">
             <motion.button
               className="auth-option secondary"
-              onClick={() => navigate('/auth')}
+              onClick={() => openAuth('signin')}
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
             >
@@ -209,7 +214,7 @@ function Navbar({ theme, toggleTheme }: LayoutProps) {
             </motion.button>
             <motion.button
               className="auth-option primary"
-              onClick={() => navigate('/auth')}
+              onClick={() => openAuth('signup')}
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
             >
@@ -443,6 +448,31 @@ function Navbar({ theme, toggleTheme }: LayoutProps) {
                 </Link>
               </motion.li>
             </ul>
+
+            {!isAuth0Authenticated && !authUser && (
+              <motion.div
+                className="mobile-menu-auth"
+                aria-label="Account actions"
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.55 }}
+              >
+                <button
+                  type="button"
+                  className="auth-option secondary"
+                  onClick={() => openAuth('signin')}
+                >
+                  Sign In
+                </button>
+                <button
+                  type="button"
+                  className="auth-option primary"
+                  onClick={() => openAuth('signup')}
+                >
+                  Sign Up
+                </button>
+              </motion.div>
+            )}
           </motion.div>
         )}
       </AnimatePresence>

--- a/frontend/src/components/styles/Navbar.css
+++ b/frontend/src/components/styles/Navbar.css
@@ -376,6 +376,19 @@
   color: var(--accent);
 }
 
+.mobile-menu-auth {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 1.25rem;
+  padding: 1.25rem 0.35rem 0;
+  border-top: 1px solid var(--border-color);
+}
+
+.mobile-menu-auth .auth-option {
+  width: 100%;
+  min-height: 44px;
+}
+
 @media (min-width: 992px) {
   .desktop-nav {
     display: block;
@@ -395,6 +408,10 @@
 @media (max-width: 991px) {
   .landing-header {
     grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .header-controls > .auth-buttons {
+    display: none;
   }
 
   .mobile-menu-toggle {

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -47,6 +47,15 @@ const getStoredItem = (key: string): string | null =>
 const getErrorMessage = (err: unknown, fallback: string): string =>
   err instanceof Error ? err.message : fallback;
 
+const getNextRewardInstanceId = (status: RewardIntegrationStatusResponse): string => {
+  const connectedInstanceIds = new Set(
+    (status.memberships || [])
+      .filter((membership) => membership.active && !membership.disabledByUser)
+      .map((membership) => membership.instanceId)
+  );
+  return status.instances.find((instance) => !connectedInstanceIds.has(instance.id))?.id || '';
+};
+
 const programmingLanguages: string[] = [
   'JavaScript',
   'Python',
@@ -194,9 +203,7 @@ function Account({ theme: _theme }: AccountProps) {
         if (shouldUpdate) {
           setPrizeversityStatus(status);
           setPrizeversityIdentifier(status.account?.email || currentUser?.email || '');
-          setSelectedRewardInstanceId(
-            status.account?.instanceId || status.instances?.[0]?.id || ''
-          );
+          setSelectedRewardInstanceId(getNextRewardInstanceId(status));
         }
       })
       .catch((err) => {
@@ -535,12 +542,19 @@ function Account({ theme: _theme }: AccountProps) {
         prizeversityIdentifier,
         selectedRewardInstanceId
       );
+      setPrizeversityStatus(response.status);
       if (response.verificationRequired && response.maskedEmail) {
         setPrizeversityVerification({
           maskedEmail: response.maskedEmail,
           expiresAt: response.expiresAt,
         });
         setPrizeversityVerificationCode('');
+      } else {
+        setPrizeversityVerification(null);
+        setPrizeversityVerificationCode('');
+        setPrizeversityIdentifier(response.status.account?.email || prizeversityIdentifier);
+        setSelectedRewardInstanceId(getNextRewardInstanceId(response.status));
+        await refreshTokens();
       }
       setSuccess(response.message);
       setTimeout(() => setSuccess(''), 4000);
@@ -563,9 +577,7 @@ function Account({ theme: _theme }: AccountProps) {
       const response = await rewardIntegrationAPI.verifyLink(prizeversityVerificationCode);
       setPrizeversityStatus(response.status);
       setPrizeversityIdentifier(response.status.account?.email || prizeversityIdentifier);
-      setSelectedRewardInstanceId(
-        response.status.account?.instanceId || response.status.instances?.[0]?.id || ''
-      );
+      setSelectedRewardInstanceId(getNextRewardInstanceId(response.status));
       setPrizeversityVerification(null);
       setPrizeversityVerificationCode('');
       await refreshTokens();
@@ -575,6 +587,28 @@ function Account({ theme: _theme }: AccountProps) {
       const message = getErrorMessage(err, 'Failed to verify Prizeversity link code');
       setPrizeversityLinkError(message);
       setError(message);
+    } finally {
+      setIsPrizeversityLoading(false);
+    }
+  };
+
+  const handlePrizeversityMembershipDisconnect = async (instanceId: string) => {
+    setIsPrizeversityLoading(true);
+    setPrizeversityLinkError('');
+    setPrizeversityVerification(null);
+    setPrizeversityVerificationCode('');
+    setError('');
+    setSuccess('');
+
+    try {
+      const response = await rewardIntegrationAPI.unlinkMembership(instanceId);
+      setPrizeversityStatus(response.status);
+      setSelectedRewardInstanceId(getNextRewardInstanceId(response.status));
+      await refreshTokens();
+      setSuccess(response.message);
+      setTimeout(() => setSuccess(''), 4000);
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to disconnect Prizeversity classroom'));
     } finally {
       setIsPrizeversityLoading(false);
     }
@@ -592,7 +626,7 @@ function Account({ theme: _theme }: AccountProps) {
       const response = await rewardIntegrationAPI.unlink();
       setPrizeversityStatus(response.status);
       setPrizeversityIdentifier(currentUser?.email || '');
-      setSelectedRewardInstanceId(response.status.instances?.[0]?.id || '');
+      setSelectedRewardInstanceId(getNextRewardInstanceId(response.status));
       await refreshTokens();
       setSuccess(response.message);
       setTimeout(() => setSuccess(''), 4000);
@@ -675,6 +709,17 @@ function Account({ theme: _theme }: AccountProps) {
   const isPrizeversityEmailDeliveryError = prizeversityLinkError
     .toLowerCase()
     .includes('verification email');
+  const prizeversityMemberships = prizeversityStatus?.memberships || [];
+  const activePrizeversityMemberships = prizeversityMemberships.filter(
+    (membership) => membership.active && !membership.disabledByUser
+  );
+  const connectedRewardInstanceIds = new Set(
+    activePrizeversityMemberships.map((membership) => membership.instanceId)
+  );
+  const availableRewardInstances =
+    prizeversityStatus?.instances.filter(
+      (instance) => !connectedRewardInstanceIds.has(instance.id)
+    ) || [];
 
   return (
     <div className="account-container">
@@ -1035,11 +1080,11 @@ function Account({ theme: _theme }: AccountProps) {
                   <Shield size={28} aria-hidden="true" />
                 </div>
                 <div className="prizeversity-title">
-                  <span>{prizeversityStatus?.linked ? 'Connected' : 'Account sync'}</span>
-                  <h3>Link your Prizeversity account</h3>
+                  <span>{prizeversityStatus?.account ? 'Identity verified' : 'Account sync'}</span>
+                  <h3>Prizeversity identity and classrooms</h3>
                   <p>
-                    Challenge completions in AWS Student Hub will use this linked Prizeversity
-                    classroom account for rewards and progression.
+                    Verify your Prizeversity identity once, then connect each classroom whose
+                    challenges and rewards you need to access.
                   </p>
                 </div>
               </div>
@@ -1048,24 +1093,29 @@ function Account({ theme: _theme }: AccountProps) {
                 <div className="prizeversity-notice">
                   Prizeversity linking requires an AWS Student Hub account session.
                 </div>
-              ) : prizeversityStatus && !prizeversityStatus.configured ? (
+              ) : !prizeversityStatus ? (
+                <div className="prizeversity-notice">Loading Prizeversity classrooms...</div>
+              ) : !prizeversityStatus.configured ? (
                 <div className="prizeversity-notice">
                   Prizeversity integration is not configured yet. An admin needs to set the backend
                   Prizeversity API URL, API key, and classroom ID.
                 </div>
               ) : (
                 <>
-                  {prizeversityStatus?.linked && prizeversityStatus.account ? (
+                  {prizeversityStatus?.account ? (
                     <div className="prizeversity-linked-panel">
-                      <div className="prizeversity-linked-grid">
+                      <div className="prizeversity-linked-heading">
                         <div>
-                          <span>Matched account</span>
+                          <span>Verified identity</span>
                           <strong>
                             {prizeversityStatus.account.matchedName ||
                               prizeversityStatus.account.email ||
                               'Prizeversity user'}
                           </strong>
                         </div>
+                        <span className="prizeversity-identity-status">Verified</span>
+                      </div>
+                      <div className="prizeversity-linked-grid">
                         <div>
                           <span>Email</span>
                           <strong>{prizeversityStatus.account.email || 'Not provided'}</strong>
@@ -1075,14 +1125,8 @@ function Account({ theme: _theme }: AccountProps) {
                           <strong>{prizeversityStatus.account.shortId || 'Not provided'}</strong>
                         </div>
                         <div>
-                          <span>Last synced</span>
-                          <strong>
-                            {prizeversityStatus.account.lastSyncedAt
-                              ? new Date(
-                                  prizeversityStatus.account.lastSyncedAt
-                                ).toLocaleDateString()
-                              : 'Just now'}
-                          </strong>
+                          <span>Connected classrooms</span>
+                          <strong>{activePrizeversityMemberships.length}</strong>
                         </div>
                       </div>
                     </div>
@@ -1093,122 +1137,207 @@ function Account({ theme: _theme }: AccountProps) {
                     </div>
                   )}
 
-                  <div className="prizeversity-link-form">
-                    {prizeversityStatus?.instances && prizeversityStatus.instances.length > 1 && (
-                      <>
-                        <label htmlFor="prizeversity-instance">Reward classroom</label>
-                        <select
-                          id="prizeversity-instance"
-                          value={selectedRewardInstanceId}
-                          onChange={(event) => setSelectedRewardInstanceId(event.target.value)}
-                          disabled={isPrizeversityLoading}
-                          className="prizeversity-instance-select"
-                        >
-                          {prizeversityStatus.instances.map((instance) => (
-                            <option key={instance.id} value={instance.id}>
-                              {instance.name}
-                              {instance.classroomName ? ` - ${instance.classroomName}` : ''}
-                            </option>
-                          ))}
-                        </select>
-                      </>
-                    )}
-
-                    <label htmlFor="prizeversity-identifier">Prizeversity identifier</label>
-                    <div className="prizeversity-input-row">
-                      <input
-                        id="prizeversity-identifier"
-                        type="text"
-                        value={prizeversityIdentifier}
-                        onChange={(event) => {
-                          setPrizeversityIdentifier(event.target.value);
-                          setPrizeversityLinkError('');
-                          setPrizeversityVerification(null);
-                          setPrizeversityVerificationCode('');
-                        }}
-                        placeholder={currentUser?.email || 'email@example.com'}
-                        disabled={isPrizeversityLoading}
-                      />
-                      <button
-                        type="button"
-                        className="show-modal-btn"
-                        onClick={handlePrizeversityLink}
-                        disabled={isPrizeversityLoading}
-                      >
-                        {isPrizeversityLoading ? (
-                          <>
-                            <RefreshCw size={16} aria-hidden="true" /> Syncing
-                          </>
-                        ) : (
-                          <>
-                            <RefreshCw size={16} aria-hidden="true" />
-                            {prizeversityVerification
-                              ? 'Resend code'
-                              : prizeversityStatus?.linked
-                                ? 'Re-sync'
-                                : 'Send code'}
-                          </>
-                        )}
-                      </button>
-                    </div>
-                    {prizeversityVerification && (
-                      <div className="prizeversity-verification-panel">
-                        <div>
-                          <strong>Check your Prizeversity email.</strong>
-                          <span>
-                            We sent a one-time code to {prizeversityVerification.maskedEmail}. Enter
-                            it below to finish linking this account.
-                          </span>
-                        </div>
-                        <div className="prizeversity-code-row">
-                          <input
-                            type="text"
-                            inputMode="numeric"
-                            maxLength={6}
-                            value={prizeversityVerificationCode}
-                            onChange={(event) => {
-                              setPrizeversityVerificationCode(event.target.value);
-                              setPrizeversityLinkError('');
-                            }}
-                            placeholder="123456"
-                            disabled={isPrizeversityLoading}
-                          />
-                          <button
-                            type="button"
-                            className="show-modal-btn"
-                            onClick={handlePrizeversityVerify}
-                            disabled={
-                              isPrizeversityLoading ||
-                              prizeversityVerificationCode.trim().length < 6
-                            }
-                          >
-                            Verify code
-                          </button>
-                        </div>
+                  <div className="prizeversity-memberships">
+                    <div className="prizeversity-memberships-heading">
+                      <div>
+                        <span>Classroom access</span>
+                        <h4>Connected classrooms</h4>
                       </div>
-                    )}
-                    {prizeversityLinkError && (
-                      <div className="prizeversity-link-error" role="alert">
-                        <strong>
-                          {prizeversityVerification
-                            ? 'Verification failed.'
-                            : isPrizeversityEmailDeliveryError
-                              ? 'Verification email could not be sent.'
-                              : 'No Prizeversity match found.'}
-                        </strong>
-                        <span>{prizeversityLinkError}</span>
-                        <small>
-                          {prizeversityVerification
-                            ? 'Check the code from your email, or resend a new code if it expired.'
-                            : isPrizeversityEmailDeliveryError
-                              ? 'Your account was matched, but the site email provider rejected the send. Ask an admin to check SMTP credentials.'
-                              : 'Confirm you selected the right reward classroom and try your Prizeversity email, full name, or short ID.'}
-                        </small>
+                      <strong>{activePrizeversityMemberships.length} active</strong>
+                    </div>
+
+                    {prizeversityMemberships.length === 0 ? (
+                      <div className="prizeversity-memberships-empty">
+                        No classrooms are connected yet. Select the exact class below to begin.
+                      </div>
+                    ) : (
+                      <div className="prizeversity-membership-list">
+                        {prizeversityMemberships.map((membership) => {
+                          const membershipActive = membership.active && !membership.disabledByUser;
+                          const membershipStatus = membershipActive
+                            ? 'Connected'
+                            : membership.disabledByUser
+                              ? 'Disconnected'
+                              : 'No longer enrolled';
+
+                          return (
+                            <article
+                              key={membership.id}
+                              className={`prizeversity-membership ${membershipActive ? 'active' : 'inactive'}`}
+                            >
+                              <div className="prizeversity-membership-main">
+                                <div>
+                                  <span>{membership.instanceName || 'Reward classroom'}</span>
+                                  <strong>
+                                    {membership.classroomName || membership.classroomId}
+                                  </strong>
+                                </div>
+                                <span className="prizeversity-membership-status">
+                                  {membershipStatus}
+                                </span>
+                              </div>
+                              <div className="prizeversity-membership-meta">
+                                <span>Short ID: {membership.shortId || 'Not provided'}</span>
+                                <span>
+                                  Last checked:{' '}
+                                  {membership.lastVerifiedAt
+                                    ? new Date(membership.lastVerifiedAt).toLocaleDateString()
+                                    : 'Not yet'}
+                                </span>
+                              </div>
+                              {!membershipActive && membership.lastVerificationError && (
+                                <small>{membership.lastVerificationError}</small>
+                              )}
+                              {membershipActive && (
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    handlePrizeversityMembershipDisconnect(membership.instanceId)
+                                  }
+                                  disabled={isPrizeversityLoading}
+                                >
+                                  Disconnect classroom
+                                </button>
+                              )}
+                            </article>
+                          );
+                        })}
                       </div>
                     )}
                   </div>
 
-                  {prizeversityStatus?.linked && (
+                  {availableRewardInstances.length > 0 ? (
+                    <div className="prizeversity-link-form">
+                      <div className="prizeversity-link-form-heading">
+                        <span>Add classroom</span>
+                        <p>
+                          Choose the configured class you joined in Prizeversity. Existing verified
+                          identities connect additional classrooms without another email code.
+                        </p>
+                      </div>
+
+                      <label htmlFor="prizeversity-instance">Classroom to connect</label>
+                      <select
+                        id="prizeversity-instance"
+                        value={selectedRewardInstanceId}
+                        onChange={(event) => {
+                          setSelectedRewardInstanceId(event.target.value);
+                          setPrizeversityLinkError('');
+                          setPrizeversityVerification(null);
+                          setPrizeversityVerificationCode('');
+                        }}
+                        disabled={isPrizeversityLoading}
+                        className="prizeversity-instance-select"
+                      >
+                        {availableRewardInstances.map((instance) => (
+                          <option key={instance.id} value={instance.id}>
+                            {instance.name}
+                            {instance.classroomName ? ` - ${instance.classroomName}` : ''}
+                          </option>
+                        ))}
+                      </select>
+
+                      <label htmlFor="prizeversity-identifier">Prizeversity identifier</label>
+                      <div className="prizeversity-input-row">
+                        <input
+                          id="prizeversity-identifier"
+                          type="text"
+                          value={prizeversityIdentifier}
+                          onChange={(event) => {
+                            setPrizeversityIdentifier(event.target.value);
+                            setPrizeversityLinkError('');
+                            setPrizeversityVerification(null);
+                            setPrizeversityVerificationCode('');
+                          }}
+                          placeholder={currentUser?.email || 'email@example.com'}
+                          disabled={isPrizeversityLoading}
+                        />
+                        <button
+                          type="button"
+                          className="show-modal-btn"
+                          onClick={handlePrizeversityLink}
+                          disabled={isPrizeversityLoading || !selectedRewardInstanceId}
+                        >
+                          {isPrizeversityLoading ? (
+                            <>
+                              <RefreshCw size={16} aria-hidden="true" /> Connecting
+                            </>
+                          ) : (
+                            <>
+                              <RefreshCw size={16} aria-hidden="true" />
+                              {prizeversityVerification
+                                ? 'Resend code'
+                                : prizeversityStatus?.account
+                                  ? 'Connect classroom'
+                                  : 'Send code'}
+                            </>
+                          )}
+                        </button>
+                      </div>
+                      {prizeversityVerification && (
+                        <div className="prizeversity-verification-panel">
+                          <div>
+                            <strong>Check your Prizeversity email.</strong>
+                            <span>
+                              We sent a one-time code to {prizeversityVerification.maskedEmail}.
+                              Enter it below to verify your identity and connect this classroom.
+                            </span>
+                          </div>
+                          <div className="prizeversity-code-row">
+                            <input
+                              type="text"
+                              inputMode="numeric"
+                              maxLength={6}
+                              value={prizeversityVerificationCode}
+                              onChange={(event) => {
+                                setPrizeversityVerificationCode(event.target.value);
+                                setPrizeversityLinkError('');
+                              }}
+                              placeholder="123456"
+                              disabled={isPrizeversityLoading}
+                            />
+                            <button
+                              type="button"
+                              className="show-modal-btn"
+                              onClick={handlePrizeversityVerify}
+                              disabled={
+                                isPrizeversityLoading ||
+                                prizeversityVerificationCode.trim().length < 6
+                              }
+                            >
+                              Verify code
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  ) : (
+                    <div className="prizeversity-all-connected">
+                      Every configured Prizeversity classroom is connected to this account.
+                    </div>
+                  )}
+
+                  {prizeversityLinkError && (
+                    <div className="prizeversity-link-error" role="alert">
+                      <strong>
+                        {prizeversityVerification
+                          ? 'Verification failed.'
+                          : isPrizeversityEmailDeliveryError
+                            ? 'Verification email could not be sent.'
+                            : 'No classroom member found.'}
+                      </strong>
+                      <span>{prizeversityLinkError}</span>
+                      <small>
+                        {prizeversityVerification
+                          ? 'Check the code from your email, or resend a new code if it expired.'
+                          : isPrizeversityEmailDeliveryError
+                            ? 'Your account was matched, but the site email provider rejected the send. Ask an admin to check SMTP credentials.'
+                            : 'Confirm you joined the selected Prizeversity classroom, then try your email, full name, or short ID again.'}
+                      </small>
+                    </div>
+                  )}
+
+                  {prizeversityStatus?.account && (
                     <div className="account-challenge-actions compact">
                       <button
                         type="button"
@@ -1216,7 +1345,7 @@ function Account({ theme: _theme }: AccountProps) {
                         onClick={handlePrizeversityUnlink}
                         disabled={isPrizeversityLoading}
                       >
-                        <Unlink size={16} aria-hidden="true" /> Unlink Prizeversity
+                        <Unlink size={16} aria-hidden="true" /> Remove identity and all classrooms
                       </button>
                     </div>
                   )}

--- a/frontend/src/pages/Auth.tsx
+++ b/frontend/src/pages/Auth.tsx
@@ -82,10 +82,14 @@ type ForgotPasswordStep =
 type AuthRequestData = Omit<AuthFormData, 'confirmPassword'>;
 
 interface ForgotPasswordResponse {
+  success?: boolean;
+  message?: string;
   needsEmailVerification?: boolean;
   censoredEmail?: string;
-  [key: string]: any;
 }
+
+const PASSWORD_RESET_REQUEST_MESSAGE =
+  'If an account exists for that email, a verification code is on its way. If it does not arrive, check your spam or junk folder.';
 
 const initialResetData: ResetData = {
   identifier: '',
@@ -402,7 +406,7 @@ function Auth({ theme: _theme }: AuthProps) {
         setForgotPasswordStep('verify-email');
       } else {
         setForgotPasswordStep('verify-code');
-        showToast('Reset code sent to your email address', 'success');
+        showToast(data.message || PASSWORD_RESET_REQUEST_MESSAGE, 'success');
       }
     } catch (err) {
       setError(getErrorMessage(err, 'Failed to send reset code'));
@@ -417,10 +421,13 @@ function Auth({ theme: _theme }: AuthProps) {
     setIsLoading(true);
 
     try {
-      await authAPI.verifyEmail(resetData.identifier, resetData.email);
+      const data = (await authAPI.verifyEmail(
+        resetData.identifier,
+        resetData.email
+      )) as ForgotPasswordResponse;
 
       setForgotPasswordStep('verify-code');
-      showToast('Reset code sent to your email address', 'success');
+      showToast(data.message || PASSWORD_RESET_REQUEST_MESSAGE, 'success');
     } catch (err) {
       setError(getErrorMessage(err, 'Failed to verify email'));
     } finally {
@@ -679,6 +686,7 @@ function Auth({ theme: _theme }: AuthProps) {
               animate={{ opacity: 1, x: 0 }}
               exit={{ opacity: 0, x: -20 }}
             >
+              <p className="verify-email-text">{PASSWORD_RESET_REQUEST_MESSAGE}</p>
               <div className="form-group">
                 <input
                   type="text"

--- a/frontend/src/pages/ChallengeDetail.tsx
+++ b/frontend/src/pages/ChallengeDetail.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { motion } from 'motion/react';
 import {
   ArrowLeft,
@@ -68,6 +68,8 @@ const getRewardStatusCopy = (
 
 function ChallengeDetail({ theme: _theme }: ThemeProps) {
   const { slug = '' } = useParams();
+  const [searchParams] = useSearchParams();
+  const assignmentId = searchParams.get('assignmentId');
   const navigate = useNavigate();
   const { user } = useAuth();
   const [challenge, setChallenge] = useState<ChallengeDetailType | null>(null);
@@ -82,6 +84,9 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
   const [success, setSuccess] = useState('');
   const [rewardModalOpen, setRewardModalOpen] = useState(false);
   const [lastSubmitReward, setLastSubmitReward] = useState<ChallengeSubmitResponse['reward']>();
+  const assignmentQuery = assignmentId ? `?assignmentId=${encodeURIComponent(assignmentId)}` : '';
+  const challengePath = `/challenges/${slug}${assignmentQuery}`;
+  const labPath = `/challenges/${slug}/lab${assignmentQuery}`;
 
   useEffect(() => {
     let shouldUpdate = true;
@@ -89,7 +94,7 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
     setError('');
 
     challengeAPI
-      .get(slug)
+      .get(slug, assignmentId)
       .then((response) => {
         if (!shouldUpdate) return;
         setChallenge(response.challenge);
@@ -108,7 +113,7 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
     return () => {
       shouldUpdate = false;
     };
-  }, [slug]);
+  }, [assignmentId, slug]);
 
   const isCompleted = completedStatuses.has(progress?.status || '');
   const isManualReview = challenge?.validationType === 'manual_review';
@@ -124,7 +129,7 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
   );
   const handleStart = async () => {
     if (!user) {
-      navigate(`/auth?redirect=/challenges/${slug}`);
+      navigate(`/auth?redirect=${encodeURIComponent(challengePath)}`);
       return;
     }
 
@@ -133,11 +138,11 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
     setSuccess('');
 
     try {
-      const response = await challengeAPI.start(slug);
+      const response = await challengeAPI.start(slug, assignmentId);
       setChallenge(response.challenge);
       setProgress(response.progress);
       if (response.challenge.experience?.type === 'sql_injection') {
-        navigate(`/challenges/${slug}/lab`);
+        navigate(labPath);
         return;
       }
       setSuccess('Challenge started.');
@@ -168,7 +173,8 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
     try {
       const response = await challengeAPI.submit(
         slug,
-        isManualReview ? { proof: secret } : isPcapForensics ? { flag: secret } : { secret }
+        isManualReview ? { proof: secret } : isPcapForensics ? { flag: secret } : { secret },
+        assignmentId
       );
       setProgress(response.progress);
       setSuccess(response.message);
@@ -190,7 +196,7 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
     setDownloadingCapture(true);
     setError('');
     try {
-      const capture = await challengeAPI.downloadPcapCapture(slug);
+      const capture = await challengeAPI.downloadPcapCapture(slug, assignmentId);
       const downloadUrl = URL.createObjectURL(capture);
       const link = document.createElement('a');
       link.href = downloadUrl;
@@ -242,7 +248,12 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
           animate={{ opacity: 1, y: 0 }}
         >
           <div>
-            <span className="challenge-detail-eyebrow">{challenge.difficulty}</span>
+            <span className="challenge-detail-eyebrow">
+              {challenge.difficulty}
+              {challenge.classroom
+                ? ` / ${challenge.classroom.classroomName || challenge.classroom.instanceName}`
+                : ''}
+            </span>
             <h1>{challenge.title}</h1>
             <p>{challenge.summary}</p>
           </div>
@@ -390,7 +401,7 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
                 <p>Sign in to start this challenge and submit proof.</p>
                 <button
                   type="button"
-                  onClick={() => navigate(`/auth?redirect=/challenges/${slug}`)}
+                  onClick={() => navigate(`/auth?redirect=${encodeURIComponent(challengePath)}`)}
                 >
                   Sign in
                 </button>
@@ -416,7 +427,7 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
                 )}
                 {progress.lastValidationMessage && <small>{progress.lastValidationMessage}</small>}
                 {isSqlInjection && (
-                  <button type="button" onClick={() => navigate(`/challenges/${slug}/lab`)}>
+                  <button type="button" onClick={() => navigate(labPath)}>
                     <Database size={16} aria-hidden="true" /> Reopen sandbox
                   </button>
                 )}
@@ -452,7 +463,7 @@ function ChallengeDetail({ theme: _theme }: ThemeProps) {
                   Open the synthetic archive database, manipulate its vulnerable search query, and
                   recover your personalized completion flag.
                 </small>
-                <button type="button" onClick={() => navigate(`/challenges/${slug}/lab`)}>
+                <button type="button" onClick={() => navigate(labPath)}>
                   Open SQL sandbox
                 </button>
               </div>

--- a/frontend/src/pages/Challenges.tsx
+++ b/frontend/src/pages/Challenges.tsx
@@ -88,6 +88,10 @@ function Challenges({ theme: _theme }: ThemeProps) {
   const challenges = challengeResponse?.challenges || [];
   const rewardLinked = Boolean(rewardLink?.linked);
   const rewardConfigured = Boolean(rewardLink?.configured);
+  const linkedInstanceIds = new Set(rewardLink?.linkedInstanceIds || []);
+  const classroomCount = new Set(
+    challenges.map((challenge) => challenge.rewardIntegrationInstanceId).filter(Boolean)
+  ).size;
 
   const handleSignIn = () => {
     navigate('/auth?redirect=/challenges');
@@ -231,13 +235,16 @@ function Challenges({ theme: _theme }: ThemeProps) {
           ) : (
             filteredChallenges.map((challenge, index) => {
               const completed = completedStatuses.has(challenge.progress?.status || '');
+              const challengeRewardLinked = challenge.rewardIntegrationInstanceId
+                ? linkedInstanceIds.has(challenge.rewardIntegrationInstanceId)
+                : rewardLinked;
               const locked = Boolean(
-                challenge.reward.enabled && user && rewardLink && !rewardLinked
+                challenge.reward.enabled && user && rewardLink && !challengeRewardLinked
               );
 
               return (
                 <motion.article
-                  key={challenge.id}
+                  key={challenge.assignmentId || challenge.id}
                   className={`challenge-card ${completed ? 'completed' : ''} ${locked ? 'locked' : ''}`}
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
@@ -245,12 +252,19 @@ function Challenges({ theme: _theme }: ThemeProps) {
                   whileHover={{ scale: 1.02, y: -4 }}
                 >
                   <div className="challenge-card-header">
-                    <span
-                      className="challenge-difficulty"
-                      style={{ color: difficultyColors[challenge.difficulty] || '#94a3b8' }}
-                    >
-                      {formatDifficulty(challenge.difficulty)}
-                    </span>
+                    <div className="challenge-card-context">
+                      <span
+                        className="challenge-difficulty"
+                        style={{ color: difficultyColors[challenge.difficulty] || '#94a3b8' }}
+                      >
+                        {formatDifficulty(challenge.difficulty)}
+                      </span>
+                      {challenge.classroom && classroomCount > 1 && (
+                        <span className="challenge-classroom">
+                          {challenge.classroom.classroomName || challenge.classroom.instanceName}
+                        </span>
+                      )}
+                    </div>
                     {challenge.reward.enabled && (
                       <span className="challenge-points">{challenge.reward.bits} bits</span>
                     )}
@@ -280,7 +294,15 @@ function Challenges({ theme: _theme }: ThemeProps) {
                     <button
                       type="button"
                       className="challenge-start-btn"
-                      onClick={() => navigate(`/challenges/${challenge.slug}`)}
+                      onClick={() =>
+                        navigate(
+                          `/challenges/${challenge.slug}${
+                            challenge.assignmentId
+                              ? `?assignmentId=${encodeURIComponent(challenge.assignmentId)}`
+                              : ''
+                          }`
+                        )
+                      }
                     >
                       {completed
                         ? 'Review'

--- a/frontend/src/pages/styles/Account.css
+++ b/frontend/src/pages/styles/Account.css
@@ -973,6 +973,50 @@
   padding: 1rem;
 }
 
+.prizeversity-linked-heading,
+.prizeversity-memberships-heading,
+.prizeversity-membership-main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.prizeversity-linked-heading {
+  padding-bottom: 0.9rem;
+  margin-bottom: 0.9rem;
+  border-bottom: 1px solid rgba(var(--accent-rgb), 0.14);
+}
+
+.prizeversity-linked-heading div > span,
+.prizeversity-memberships-heading div > span,
+.prizeversity-link-form-heading > span {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.prizeversity-linked-heading strong {
+  display: block;
+  margin-top: 0.2rem;
+  color: var(--text-primary);
+}
+
+.prizeversity-identity-status,
+.prizeversity-membership-status {
+  flex-shrink: 0;
+  border-radius: 999px;
+  padding: 0.35rem 0.65rem;
+  color: #166534;
+  background: rgba(34, 197, 94, 0.12);
+  border: 1px solid rgba(34, 197, 94, 0.22);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
 .prizeversity-linked-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1001,8 +1045,118 @@
   word-break: break-word;
 }
 
+.prizeversity-memberships {
+  margin-top: 1rem;
+  border: 1px solid var(--challenge-border);
+  border-radius: 18px;
+  padding: 1rem;
+}
+
+.prizeversity-memberships-heading h4 {
+  margin: 0.2rem 0 0;
+  color: var(--text-primary);
+  font-size: 1rem;
+}
+
+.prizeversity-memberships-heading > strong {
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.prizeversity-memberships-empty,
+.prizeversity-all-connected {
+  margin-top: 0.9rem;
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  color: var(--text-secondary);
+  background: rgba(var(--text-primary-rgb), 0.035);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.prizeversity-membership-list {
+  display: grid;
+  gap: 0.7rem;
+  margin-top: 0.9rem;
+}
+
+.prizeversity-membership {
+  display: grid;
+  gap: 0.65rem;
+  padding: 0.9rem;
+  border: 1px solid rgba(var(--text-primary-rgb), 0.09);
+  border-radius: 14px;
+  background: rgba(var(--text-primary-rgb), 0.025);
+}
+
+.prizeversity-membership.inactive {
+  opacity: 0.78;
+}
+
+.prizeversity-membership-main div > span {
+  display: block;
+  margin-bottom: 0.18rem;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.prizeversity-membership-main div > strong {
+  color: var(--text-primary);
+  font-size: 0.95rem;
+}
+
+.prizeversity-membership.inactive .prizeversity-membership-status {
+  color: var(--text-secondary);
+  background: rgba(var(--text-primary-rgb), 0.05);
+  border-color: rgba(var(--text-primary-rgb), 0.1);
+}
+
+.prizeversity-membership-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1rem;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+}
+
+.prizeversity-membership > small {
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.prizeversity-membership > button {
+  justify-self: start;
+  border: 0;
+  padding: 0;
+  color: var(--text-secondary);
+  background: transparent;
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.prizeversity-membership > button:hover {
+  color: var(--accent);
+}
+
 .prizeversity-link-form {
   margin-top: 1rem;
+  border: 1px solid var(--challenge-border);
+  border-radius: 18px;
+  padding: 1rem;
+}
+
+.prizeversity-link-form-heading {
+  margin-bottom: 1rem;
+}
+
+.prizeversity-link-form-heading p {
+  margin: 0.3rem 0 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.5;
 }
 
 .prizeversity-input-row {
@@ -1471,6 +1625,16 @@
 
   .prizeversity-header {
     align-items: flex-start;
+  }
+
+  .prizeversity-linked-heading,
+  .prizeversity-memberships-heading,
+  .prizeversity-membership-main {
+    align-items: flex-start;
+  }
+
+  .prizeversity-membership-meta {
+    flex-direction: column;
   }
 
   .prizeversity-linked-grid,

--- a/frontend/src/pages/styles/Challenges.css
+++ b/frontend/src/pages/styles/Challenges.css
@@ -271,6 +271,22 @@
   align-items: center;
 }
 
+.challenge-card-context {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.challenge-classroom {
+  padding-left: 0.55rem;
+  border-left: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
 .challenge-difficulty {
   font-size: 0.85rem;
   font-weight: 600;

--- a/frontend/src/types/challenge.ts
+++ b/frontend/src/types/challenge.ts
@@ -96,6 +96,12 @@ export interface ChallengeListItem {
   startsAt?: string | null;
   endsAt?: string | null;
   rewardIntegrationInstanceId?: string | null;
+  classroom?: {
+    instanceId: string;
+    instanceName: string;
+    classroomId: string;
+    classroomName?: string;
+  };
   reward: ChallengeRewardPreview;
   maxAttempts?: number;
   progress?: ChallengeProgress;
@@ -112,6 +118,7 @@ export interface ChallengeRewardLinkSummary {
   configured: boolean;
   requiredInstanceId?: string | null;
   linkedInstanceId?: string | null;
+  linkedInstanceIds: string[];
 }
 
 export interface ChallengeListResponse {

--- a/frontend/src/types/rewardIntegration.ts
+++ b/frontend/src/types/rewardIntegration.ts
@@ -31,11 +31,29 @@ export interface RewardIntegrationInstance {
   updatedAt?: string;
 }
 
+export interface RewardIntegrationMembership {
+  id: string;
+  instanceId: string;
+  instanceName?: string;
+  classroomId: string;
+  classroomName?: string;
+  userId: string;
+  email?: string;
+  matchedName?: string;
+  shortId?: string;
+  active: boolean;
+  disabledByUser: boolean;
+  linkedAt: string;
+  lastVerifiedAt?: string | null;
+  lastVerificationError?: string;
+}
+
 export interface RewardIntegrationStatusResponse {
   configured: boolean;
   linked: boolean;
   missingConfig: string[];
   account: LinkedRewardAccount | null;
+  memberships: RewardIntegrationMembership[];
   instances: RewardIntegrationInstance[];
 }
 
@@ -46,6 +64,7 @@ export interface RewardIntegrationLinkResponse {
   verificationRequired?: boolean;
   maskedEmail?: string;
   expiresAt?: string;
+  membership?: RewardIntegrationMembership;
 }
 
 export interface RewardIntegrationInstancePayload {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -606,67 +606,119 @@ export const rewardIntegrationAPI = {
       method: 'DELETE',
     });
   },
+
+  unlinkMembership: async (instanceId: string): Promise<RewardIntegrationLinkResponse> => {
+    return apiRequest(`/integrations/prizeversity/link/${encodeURIComponent(instanceId)}`, {
+      method: 'DELETE',
+    });
+  },
 };
+
+const withChallengeAssignment = (path: string, assignmentId?: string | null): string =>
+  assignmentId ? `${path}?assignmentId=${encodeURIComponent(assignmentId)}` : path;
 
 export const challengeAPI = {
   list: async (): Promise<ChallengeListResponse> => {
     return apiRequest('/challenges');
   },
 
-  get: async (slug: string): Promise<ChallengeDetailResponse> => {
-    return apiRequest(`/challenges/${encodeURIComponent(slug)}`);
+  get: async (slug: string, assignmentId?: string | null): Promise<ChallengeDetailResponse> => {
+    return apiRequest(
+      withChallengeAssignment(`/challenges/${encodeURIComponent(slug)}`, assignmentId)
+    );
   },
 
-  getCipheredSealState: async (routeKey: string): Promise<CipheredSealRouteStateResponse> => {
-    return apiRequest(`/challenges/ciphered-seal/route/${encodeURIComponent(routeKey)}`);
+  getCipheredSealState: async (
+    routeKey: string,
+    assignmentId?: string | null
+  ): Promise<CipheredSealRouteStateResponse> => {
+    return apiRequest(
+      withChallengeAssignment(
+        `/challenges/ciphered-seal/route/${encodeURIComponent(routeKey)}`,
+        assignmentId
+      )
+    );
   },
 
   resolveCipheredSealSeed: async (
     routeKey: string,
-    seedNumber: number
+    seedNumber: number,
+    assignmentId?: string | null
   ): Promise<CipheredSealResolveResponse> => {
-    return apiRequest(`/challenges/ciphered-seal/route/${encodeURIComponent(routeKey)}/resolve`, {
-      method: 'POST',
-      body: JSON.stringify({ seedNumber }),
-    });
+    return apiRequest(
+      withChallengeAssignment(
+        `/challenges/ciphered-seal/route/${encodeURIComponent(routeKey)}/resolve`,
+        assignmentId
+      ),
+      {
+        method: 'POST',
+        body: JSON.stringify({ seedNumber }),
+      }
+    );
   },
 
-  getSqlInjectionSandbox: async (slug: string): Promise<SqlInjectionSandboxStateResponse> => {
-    return apiRequest(`/challenges/${encodeURIComponent(slug)}/sql-sandbox`);
+  getSqlInjectionSandbox: async (
+    slug: string,
+    assignmentId?: string | null
+  ): Promise<SqlInjectionSandboxStateResponse> => {
+    return apiRequest(
+      withChallengeAssignment(`/challenges/${encodeURIComponent(slug)}/sql-sandbox`, assignmentId)
+    );
   },
 
   searchSqlInjectionSandbox: async (
     slug: string,
-    query: string
+    query: string,
+    assignmentId?: string | null
   ): Promise<SqlInjectionSandboxSearchResponse> => {
-    return apiRequest(`/challenges/${encodeURIComponent(slug)}/sql-sandbox/search`, {
-      method: 'POST',
-      body: JSON.stringify({ query }),
-    });
+    return apiRequest(
+      withChallengeAssignment(
+        `/challenges/${encodeURIComponent(slug)}/sql-sandbox/search`,
+        assignmentId
+      ),
+      {
+        method: 'POST',
+        body: JSON.stringify({ query }),
+      }
+    );
   },
 
-  downloadPcapCapture: async (slug: string): Promise<Blob> => {
-    return apiBlobRequest(`/challenges/${encodeURIComponent(slug)}/pcap`);
+  downloadPcapCapture: async (slug: string, assignmentId?: string | null): Promise<Blob> => {
+    return apiBlobRequest(
+      withChallengeAssignment(`/challenges/${encodeURIComponent(slug)}/pcap`, assignmentId)
+    );
   },
 
-  progress: async (slug: string): Promise<ChallengeProgressResponse> => {
-    return apiRequest(`/challenges/${encodeURIComponent(slug)}/progress`);
+  progress: async (
+    slug: string,
+    assignmentId?: string | null
+  ): Promise<ChallengeProgressResponse> => {
+    return apiRequest(
+      withChallengeAssignment(`/challenges/${encodeURIComponent(slug)}/progress`, assignmentId)
+    );
   },
 
-  start: async (slug: string): Promise<ChallengeProgressResponse> => {
-    return apiRequest(`/challenges/${encodeURIComponent(slug)}/start`, {
-      method: 'POST',
-    });
+  start: async (slug: string, assignmentId?: string | null): Promise<ChallengeProgressResponse> => {
+    return apiRequest(
+      withChallengeAssignment(`/challenges/${encodeURIComponent(slug)}/start`, assignmentId),
+      {
+        method: 'POST',
+      }
+    );
   },
 
   submit: async (
     slug: string,
-    payload: Record<string, unknown>
+    payload: Record<string, unknown>,
+    assignmentId?: string | null
   ): Promise<ChallengeSubmitResponse> => {
-    return apiRequest(`/challenges/${encodeURIComponent(slug)}/submit`, {
-      method: 'POST',
-      body: JSON.stringify({ payload }),
-    });
+    return apiRequest(
+      withChallengeAssignment(`/challenges/${encodeURIComponent(slug)}/submit`, assignmentId),
+      {
+        method: 'POST',
+        body: JSON.stringify({ payload }),
+      }
+    );
   },
 };
 


### PR DESCRIPTION
Replaces the single-class Prizeversity link with one verified identity that can connect to multiple classroom instances. Challenge visibility, progress, and reward delivery are now scoped to the originating classroom assignment and API credentials. Adds roster revalidation, per-class disconnect controls, legacy-link migration, account cleanup, clearer linking errors, and updated operational documentation.

Also fixes various UI/UX around auth. 